### PR TITLE
[Refactor/#173] convert create & write api related to imgFile

### DIFF
--- a/src/main/java/com/example/waggle/domain/media/service/MediaCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/media/service/MediaCommandServiceImpl.java
@@ -6,6 +6,8 @@ import com.example.waggle.domain.media.repository.MediaRepository;
 import com.example.waggle.domain.member.repository.MemberRepository;
 import com.example.waggle.domain.pet.repository.PetRepository;
 import com.example.waggle.domain.schedule.repository.TeamRepository;
+import com.example.waggle.global.exception.handler.MediaHandler;
+import com.example.waggle.global.payload.code.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -31,6 +33,9 @@ public class MediaCommandServiceImpl implements MediaCommandService {
 
     @Override
     public void createMedia(List<String> imgUrlList, Board board) {
+        if (imgUrlList.contains(null)) {
+            throw new MediaHandler(ErrorStatus.MEDIA_PREFIX_IS_WRONG);
+        }
         List<Media> mediaList = imgUrlList.stream().map(img -> Media.builder()
                 .uploadFile(img)
                 .board(board)

--- a/src/main/java/com/example/waggle/web/controller/MemberApiController.java
+++ b/src/main/java/com/example/waggle/web/controller/MemberApiController.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -58,9 +59,9 @@ public class MemberApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PutMapping("/info")
+    @PutMapping(value = "/info", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponseDto<Long> initializeMemberProfile(
-            @RequestBody MemberProfileDto memberProfileRequest,
+            @RequestPart("memberProfileRequest") MemberProfileDto memberProfileRequest,
             @AuthUser Member member) {
         memberProfileRequest.setMemberProfileImg(MediaUtil.removePrefix(memberProfileRequest.getMemberProfileImg()));
         Long memberId = memberCommandService.initializeMemberProfile(memberProfileRequest, member);
@@ -71,8 +72,8 @@ public class MemberApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PutMapping
-    public ApiResponseDto<Long> updateInfo(@RequestBody MemberUpdateDto updateMemberRequest,
+    @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponseDto<Long> updateInfo(@RequestPart("updateMemberRequest") MemberUpdateDto updateMemberRequest,
                                            @AuthUser Member member) {
         updateMemberRequest.setMemberProfileImg(MediaUtil.removePrefix(updateMemberRequest.getMemberProfileImg()));
         Long memberId = memberCommandService.updateMemberProfile(updateMemberRequest, member);

--- a/src/main/java/com/example/waggle/web/controller/PetApiController.java
+++ b/src/main/java/com/example/waggle/web/controller/PetApiController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,8 +38,8 @@ public class PetApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PostMapping
-    public ApiResponseDto<Long> createPet(@RequestBody @Validated PetRequest createPetRequest,
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponseDto<Long> createPet(@RequestPart("createPetRequest") @Validated PetRequest createPetRequest,
                                           @AuthUser Member member) {
         createPetRequest.setPetProfileImg(MediaUtil.removePrefix(createPetRequest.getPetProfileImg()));
         Long petId = petCommandService.createPet(createPetRequest, member);
@@ -50,9 +51,9 @@ public class PetApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PutMapping("/{petId}")
+    @PutMapping(value = "/{petId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponseDto<Long> updatePet(@PathVariable("petId") Long petId,
-                                          @RequestBody @Validated PetRequest updatePetRequest,
+                                          @RequestPart("updatePetRequest") @Validated PetRequest updatePetRequest,
                                           @AuthUser Member member) {
         updatePetRequest.setPetProfileImg(MediaUtil.removePrefix(updatePetRequest.getPetProfileImg()));
         Long result = petCommandService.updatePet(petId, updatePetRequest, member);

--- a/src/main/java/com/example/waggle/web/controller/QuestionApiController.java
+++ b/src/main/java/com/example/waggle/web/controller/QuestionApiController.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -48,9 +49,9 @@ public class QuestionApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponseDto<Long> createQuestion(
-            @RequestBody @Validated QuestionRequest createQuestionRequest,
+            @RequestPart("createQuestionRequest") @Validated QuestionRequest createQuestionRequest,
             @AuthUser Member member) {
         List<String> removedPrefixMedia = createQuestionRequest.getMediaList().stream()
                 .map(media -> MediaUtil.removePrefix(media)).collect(Collectors.toList());
@@ -63,9 +64,9 @@ public class QuestionApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PutMapping(value = "/{questionId}")
+    @PutMapping(value = "/{questionId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponseDto<Long> updateQuestion(@PathVariable("questionId") Long questionId,
-                                               @RequestBody @Validated QuestionRequest updateQuestionRequest,
+                                               @RequestPart("updateQuestionRequest") @Validated QuestionRequest updateQuestionRequest,
                                                @AuthUser Member member) {
         List<String> removedPrefixMedia = updateQuestionRequest.getMediaList().stream()
                 .map(media -> MediaUtil.removePrefix(media)).collect(Collectors.toList());

--- a/src/main/java/com/example/waggle/web/controller/SirenApiController.java
+++ b/src/main/java/com/example/waggle/web/controller/SirenApiController.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -49,9 +50,9 @@ public class SirenApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponseDto<Long> createSiren(
-            @RequestBody @Validated SirenRequest createSirenRequest,
+            @RequestPart("createSirenRequest") @Validated SirenRequest createSirenRequest,
             @AuthUser Member member) {
         List<String> removedPrefixMedia = createSirenRequest.getMediaList().stream()
                 .map(media -> MediaUtil.removePrefix(media)).collect(Collectors.toList());
@@ -64,9 +65,9 @@ public class SirenApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PutMapping("/{sirenId}")
+    @PutMapping(value = "/{sirenId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponseDto<Long> updateSiren(@PathVariable("sirenId") Long sirenId,
-                                            @RequestBody @Validated SirenRequest updateSirenRequest,
+                                            @RequestPart("updateSirenRequest") @Validated SirenRequest updateSirenRequest,
                                             @AuthUser Member member) {
         List<String> removedPrefixMedia = updateSirenRequest.getMediaList().stream()
                 .map(media -> MediaUtil.removePrefix(media)).collect(Collectors.toList());

--- a/src/main/java/com/example/waggle/web/controller/StoryApiController.java
+++ b/src/main/java/com/example/waggle/web/controller/StoryApiController.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -44,8 +45,8 @@ public class StoryApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PostMapping
-    public ApiResponseDto<Long> createStory(@RequestBody StoryRequest createStoryRequest,
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponseDto<Long> createStory(@RequestPart("createStoryRequest") StoryRequest createStoryRequest,
                                             @AuthUser Member member) {
         List<String> removedPrefixMedia = createStoryRequest.getMediaList().stream()
                 .map(media -> MediaUtil.removePrefix(media)).collect(Collectors.toList());
@@ -58,9 +59,9 @@ public class StoryApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PutMapping("/{storyId}")
+    @PutMapping(value = "/{storyId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponseDto<Long> updateStory(@PathVariable("storyId") Long storyId,
-                                            @RequestBody StoryRequest updateStoryRequest,
+                                            @RequestPart("updateStoryRequest") StoryRequest updateStoryRequest,
                                             @AuthUser Member member) {
         List<String> removedPrefixMedia = updateStoryRequest.getMediaList().stream()
                 .map(media -> MediaUtil.removePrefix(media)).collect(Collectors.toList());

--- a/src/main/java/com/example/waggle/web/controller/TeamApiController.java
+++ b/src/main/java/com/example/waggle/web/controller/TeamApiController.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,8 +40,8 @@ public class TeamApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PostMapping
-    public ApiResponseDto<Long> createTeam(@RequestBody @Validated TeamRequest createTeamRequest,
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponseDto<Long> createTeam(@RequestPart("createTeamRequest") @Validated TeamRequest createTeamRequest,
                                            @AuthUser Member member) {
         createTeamRequest.setCoverImageUrl(MediaUtil.removePrefix(createTeamRequest.getCoverImageUrl()));
         Long createdTeamId = teamCommandService.createTeam(createTeamRequest, member);
@@ -51,9 +52,9 @@ public class TeamApiController {
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @PutMapping("/{teamId}")
+    @PutMapping(value = "/{teamId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponseDto<Long> updateTeam(@PathVariable("teamId") Long teamId,
-                                           @RequestBody @Validated TeamRequest updateTeamRequest,
+                                           @RequestPart("updateTeamRequest") @Validated TeamRequest updateTeamRequest,
                                            @AuthUser Member member) {
         updateTeamRequest.setCoverImageUrl(MediaUtil.removePrefix(updateTeamRequest.getCoverImageUrl()));
         Long updatedTeamId = teamCommandService.updateTeam(teamId, updateTeamRequest, member);


### PR DESCRIPTION
## 🔎 Description
> 미디어 파일을 업로드하는 과정을 별도의 api로 만들었기 때문에 다른 create&write api들을 application/json 형식으로 바꿨으나,
> front에서 해당 방식이 필드 값들을 일일이 변경시켜야하기 때문에 form-data 전송 방식으로 유지를 요청


## 🔗 Related Issue
- https://github.com/teamWaggle/Waggle-server/issues/173


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [x] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
