### PR TITLE
[Refactor/#175] apply pagination in story api

### DIFF
--- a/src/main/java/com/example/waggle/global/util/PageUtil.java
+++ b/src/main/java/com/example/waggle/global/util/PageUtil.java
@@ -4,7 +4,8 @@ import com.example.waggle.domain.board.Board;
 import org.springframework.data.domain.Page;
 
 public class PageUtil {
-    private static int THIS_PAGE_IS_LAST = -1;
+    public static int THIS_PAGE_IS_LAST = -1;
+    public static int STORY_SIZE = 9;
 
     public static <T extends Board> int countNextPage(Page<T> pagedBoardList) {
         if (pagedBoardList.isLast()) return THIS_PAGE_IS_LAST;

--- a/src/main/java/com/example/waggle/global/util/PageUtil.java
+++ b/src/main/java/com/example/waggle/global/util/PageUtil.java
@@ -1,0 +1,13 @@
+package com.example.waggle.global.util;
+
+import com.example.waggle.domain.board.Board;
+import org.springframework.data.domain.Page;
+
+public class PageUtil {
+    private static int THIS_PAGE_IS_LAST = -1;
+
+    public static <T extends Board> int countNextPage(Page<T> pagedBoardList) {
+        if (pagedBoardList.isLast()) return THIS_PAGE_IS_LAST;
+        return pagedBoardList.getNumber() + 1;
+    }
+}

--- a/src/main/java/com/example/waggle/web/controller/StoryApiController.java
+++ b/src/main/java/com/example/waggle/web/controller/StoryApiController.java
@@ -10,6 +10,7 @@ import com.example.waggle.global.annotation.auth.AuthUser;
 import com.example.waggle.global.payload.ApiResponseDto;
 import com.example.waggle.global.payload.code.ErrorStatus;
 import com.example.waggle.global.util.MediaUtil;
+import com.example.waggle.global.util.PageUtil;
 import com.example.waggle.global.util.SecurityUtil;
 import com.example.waggle.web.converter.StoryConverter;
 import com.example.waggle.web.dto.story.StoryRequest;
@@ -77,7 +78,7 @@ public class StoryApiController {
     @GetMapping
     public ApiResponseDto<StorySummaryListDto> getAllStories(
             @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
-        Pageable pageable = PageRequest.of(currentPage, 10, latestSorting);
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.STORY_SIZE, latestSorting);
         return ApiResponseDto.onSuccess(
                 StoryConverter.toListDto(storyQueryService.getPagedStories(pageable)));
     }
@@ -89,7 +90,7 @@ public class StoryApiController {
     @GetMapping("/member/{memberId}")
     public ApiResponseDto<StorySummaryListDto> getStoriesByUsername(@PathVariable("memberId") Long memberId,
                                                                     @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
-        Pageable pageable = PageRequest.of(currentPage, 10, latestSorting);
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.STORY_SIZE, latestSorting);
         return ApiResponseDto.onSuccess(
                 StoryConverter.toListDto(storyQueryService.getPagedStoriesByMemberId(memberId, pageable)));
     }

--- a/src/main/java/com/example/waggle/web/converter/StoryConverter.java
+++ b/src/main/java/com/example/waggle/web/converter/StoryConverter.java
@@ -2,6 +2,7 @@ package com.example.waggle.web.converter;
 
 import com.example.waggle.domain.board.story.entity.Story;
 import com.example.waggle.global.util.MediaUtil;
+import com.example.waggle.global.util.PageUtil;
 import com.example.waggle.web.dto.story.StoryResponse.StoryDetailDto;
 import com.example.waggle.web.dto.story.StoryResponse.StorySummaryDto;
 import com.example.waggle.web.dto.story.StoryResponse.StorySummaryListDto;
@@ -24,9 +25,7 @@ public class StoryConverter {
                 .map(StoryConverter::toSummaryDto).collect(Collectors.toList());
         return StorySummaryListDto.builder()
                 .storyList(stories)
-                .storyCount(storyPage.getTotalElements())
-                .isFirst(storyPage.isFirst())
-                .isLast(storyPage.isLast())
+                .nextPageNumber(PageUtil.countNextPage(storyPage))
                 .build();
     }
 

--- a/src/main/java/com/example/waggle/web/dto/story/StoryResponse.java
+++ b/src/main/java/com/example/waggle/web/dto/story/StoryResponse.java
@@ -41,9 +41,7 @@ public class StoryResponse {
     @AllArgsConstructor
     public static class StorySummaryListDto {
         private List<StorySummaryDto> storyList;
-        private long storyCount;
-        private Boolean isFirst;
-        private Boolean isLast;
+        private int nextPageNumber;
     }
 
 }


### PR DESCRIPTION
## 🔎 Description
> front-request : response 값에 summaryList와 nextPageNumber만 받을 수 있도록. 
> PageUtil을 만들어 pagination 관리는 해당 클래스에서 할 수 있도록 함.(ex. method, value.etc)


## 🔗 Related Issue
- https://github.com/teamWaggle/Waggle-server/issues/175
- [notion/get_story_list_request](https://www.notion.so/get-story-list-pagination-4df0ecf752fe45b6b352c5d5b1f92434?pvs=4)


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [x] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
