### PR TITLE
[Hotfix/#198] Change findOverlappingSchedules query to use individual date and time parameters

### DIFF
--- a/src/main/java/com/example/waggle/domain/schedule/repository/MemberScheduleRepository.java
+++ b/src/main/java/com/example/waggle/domain/schedule/repository/MemberScheduleRepository.java
@@ -4,10 +4,10 @@ import com.example.waggle.domain.schedule.entity.MemberSchedule;
 import com.example.waggle.domain.schedule.entity.Schedule;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
 public interface MemberScheduleRepository extends JpaRepository<MemberSchedule, Long> {
     List<MemberSchedule> findByMemberId(Long memberId);
@@ -35,10 +35,13 @@ public interface MemberScheduleRepository extends JpaRepository<MemberSchedule, 
     void deleteAllBySchedule(Schedule schedule);
 
 
-    @Query("SELECT ms.schedule FROM MemberSchedule ms WHERE ms.member.id = :memberId AND (" +
-            "(ms.schedule.startDate <= :schedule.endDate AND ms.schedule.endDate >= :schedule.startDate) AND " +
-            "(ms.schedule.startTime < :schedule.endTime AND ms.schedule.endTime > :schedule.startTime))")
+    @Query("SELECT ms.schedule FROM MemberSchedule ms WHERE ms.member.id = :memberId AND " +
+            "(ms.schedule.startDate <= :endDate AND ms.schedule.endDate >= :startDate) AND " +
+            "(ms.schedule.startTime < :endTime AND ms.schedule.endTime > :startTime)")
     List<Schedule> findOverlappingSchedules(@Param("memberId") Long memberId,
-                                            @Param("schedule") Schedule schedule);
+                                            @Param("startDate") LocalDate startDate,
+                                            @Param("endDate") LocalDate endDate,
+                                            @Param("startTime") LocalTime startTime,
+                                            @Param("endTime") LocalTime endTime);
 
 }

--- a/src/main/java/com/example/waggle/domain/schedule/repository/MemberScheduleRepository.java
+++ b/src/main/java/com/example/waggle/domain/schedule/repository/MemberScheduleRepository.java
@@ -2,12 +2,12 @@ package com.example.waggle.domain.schedule.repository;
 
 import com.example.waggle.domain.schedule.entity.MemberSchedule;
 import com.example.waggle.domain.schedule.entity.Schedule;
-import io.lettuce.core.dynamic.annotation.Param;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberScheduleRepository extends JpaRepository<MemberSchedule, Long> {
     List<MemberSchedule> findByMemberId(Long memberId);

--- a/src/main/java/com/example/waggle/domain/schedule/repository/ParticipationRepository.java
+++ b/src/main/java/com/example/waggle/domain/schedule/repository/ParticipationRepository.java
@@ -2,6 +2,7 @@ package com.example.waggle.domain.schedule.repository;
 
 import com.example.waggle.domain.member.entity.Member;
 import com.example.waggle.domain.schedule.entity.Participation;
+import com.example.waggle.domain.schedule.entity.ParticipationStatus;
 import com.example.waggle.domain.schedule.entity.Team;
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +20,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     void deleteByMemberAndTeam(Member member, Team team);
 
-    List<Participation> findByTeam(Team team);
+    List<Participation> findByTeamAndStatus(Team team, ParticipationStatus status);
 
 }

--- a/src/main/java/com/example/waggle/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/waggle/domain/schedule/repository/ScheduleRepository.java
@@ -3,14 +3,13 @@ package com.example.waggle.domain.schedule.repository;
 import com.example.waggle.domain.member.entity.Member;
 import com.example.waggle.domain.schedule.entity.Schedule;
 import com.example.waggle.domain.schedule.entity.Team;
-import io.lettuce.core.dynamic.annotation.Param;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import java.time.LocalDate;
-import java.util.List;
+import org.springframework.data.repository.query.Param;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 

--- a/src/main/java/com/example/waggle/domain/schedule/service/schedule/ScheduleQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/service/schedule/ScheduleQueryServiceImpl.java
@@ -101,8 +101,12 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
     public List<Schedule> findOverlappingSchedules(Member member, Long scheduleId) {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
-        return memberScheduleRepository.findOverlappingSchedules(member.getId(), schedule);
+        return memberScheduleRepository.findOverlappingSchedules(
+                member.getId(),
+                schedule.getStartDate(),
+                schedule.getEndDate(),
+                schedule.getStartTime(),
+                schedule.getEndTime());
     }
-
 
 }

--- a/src/main/java/com/example/waggle/domain/schedule/service/team/TeamQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/service/team/TeamQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.waggle.domain.schedule.service.team;
 import com.example.waggle.domain.member.entity.Member;
 import com.example.waggle.domain.member.repository.MemberRepository;
 import com.example.waggle.domain.schedule.entity.Participation;
+import com.example.waggle.domain.schedule.entity.ParticipationStatus;
 import com.example.waggle.domain.schedule.entity.Team;
 import com.example.waggle.domain.schedule.repository.ParticipationRepository;
 import com.example.waggle.domain.schedule.repository.TeamRepository;
@@ -64,7 +65,7 @@ public class TeamQueryServiceImpl implements TeamQueryService {
         if (!team.getLeader().equals(leader)) {
             throw new TeamHandler(ErrorStatus.TEAM_LEADER_UNAUTHORIZED);
         }
-        return participationRepository.findByTeam(team);
+        return participationRepository.findByTeamAndStatus(team, ParticipationStatus.PENDING);
     }
 
     @Override

--- a/src/main/java/com/example/waggle/web/controller/ScheduleApiController.java
+++ b/src/main/java/com/example/waggle/web/controller/ScheduleApiController.java
@@ -228,6 +228,7 @@ public class ScheduleApiController {
                     .map(ScheduleConverter::toOverlappedScheduleDto)
                     .collect(Collectors.toList());
             scheduleDto.setOverlappedScheduleList(overlappedScheduleDtos);
+            scheduleDto.setOverlappedScheduleCount((int) overlappedScheduleDtos.stream().count());
         });
     }
 

--- a/src/main/java/com/example/waggle/web/dto/schedule/TeamResponse.java
+++ b/src/main/java/com/example/waggle/web/dto/schedule/TeamResponse.java
@@ -61,7 +61,7 @@ public class TeamResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema
-    public class ParticipationStatusResponse {
+    public static class ParticipationStatusResponse {
 
         private Status status;
 


### PR DESCRIPTION
## 🔎 Description
> Change findOverlappingSchedules query to use individual date and time parameters


## 🔗 Related Issue
- [https://github.com/teamWaggle/Waggle-server/issues/198](https://github.com/teamWaggle/Waggle-server/issues/198)


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [x] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
