### PR TITLE
[Feat/#229] Integrate Kafka as Message Broker for Chat Feature

### DIFF
--- a/src/main/java/com/example/waggle/domain/chat/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/example/waggle/domain/chat/config/kafka/KafkaConsumerConfig.java
@@ -1,53 +1,48 @@
-//package com.example.waggle.domain.chat.config.kafka;
-//
-//import com.example.waggle.domain.chat.entity.MessageDto;
-//import com.google.common.collect.ImmutableMap;
-//import java.util.Map;
-//import lombok.RequiredArgsConstructor;
-//import org.apache.kafka.clients.consumer.ConsumerConfig;
-//import org.apache.kafka.common.serialization.StringDeserializer;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.kafka.annotation.EnableKafka;
-//import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
-//import org.springframework.kafka.core.ConsumerFactory;
-//import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-//import org.springframework.kafka.support.serializer.JsonDeserializer;
-//
-//@RequiredArgsConstructor
-//@EnableKafka
-//@Configuration
-//public class KafkaConsumerConfig {
-//
-//    private final KafkaProperties kafkaProperties;
-//
-//
-//    // KafkaListener 컨테이너 팩토리를 생성하는 Bean 메서드
-//    @Bean
-//    ConcurrentKafkaListenerContainerFactory<String, MessageDto> kafkaListenerContainerFactory() {
-//        ConcurrentKafkaListenerContainerFactory<String, MessageDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
-//        factory.setConsumerFactory(consumerFactory());
-//        return factory;
-//    }
-//
-//    // Kafka ConsumerFactory를 생성하는 Bean 메서드
-//    @Bean
-//    public ConsumerFactory<String, MessageDto> consumerFactory() {
-//        JsonDeserializer<MessageDto> deserializer = new JsonDeserializer<>();
-//        // 패키지 신뢰 오류로 인해 모든 패키지를 신뢰하도록 작성
-//        deserializer.addTrustedPackages("*");
-//
-//        // Kafka Consumer 구성을 위한 설정값들을 설정 -> 변하지 않는 값이므로 ImmutableMap을 이용하여 설정
-//        Map<String, Object> consumerConfigurations =
-//                ImmutableMap.<String, Object>builder()
-//                        .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBroker())
-//                        .put(ConsumerConfig.GROUP_ID_CONFIG, kafkaProperties.getGroupId())
-//                        .put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
-//                        .put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer)
-//                        .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")
-//                        .build();
-//
-//        return new DefaultKafkaConsumerFactory<>(consumerConfigurations, new StringDeserializer(), deserializer);
-//    }
-//
-//}
+package com.example.waggle.domain.chat.config.kafka;
+
+import com.example.waggle.web.dto.chat.ChatMessageDto;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@RequiredArgsConstructor
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    ConcurrentKafkaListenerContainerFactory<String, ChatMessageDto> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ChatMessageDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, ChatMessageDto> consumerFactory() {
+        JsonDeserializer<ChatMessageDto> deserializer = new JsonDeserializer<>();
+        deserializer.addTrustedPackages("*");
+
+        Map<String, Object> consumerConfigurations =
+                ImmutableMap.<String, Object>builder()
+                        .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBroker())
+                        .put(ConsumerConfig.GROUP_ID_CONFIG, kafkaProperties.getGroupId())
+                        .put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                        .put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer)
+                        .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")
+                        .build();
+
+        return new DefaultKafkaConsumerFactory<>(consumerConfigurations, new StringDeserializer(), deserializer);
+    }
+
+}

--- a/src/main/java/com/example/waggle/domain/chat/config/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/example/waggle/domain/chat/config/kafka/KafkaProducerConfig.java
@@ -1,46 +1,43 @@
-//package com.example.waggle.domain.chat.config.kafka;
-//
-//import com.example.waggle.domain.chat.entity.MessageDto;
-//import com.google.common.collect.ImmutableMap;
-//import java.util.Map;
-//import lombok.RequiredArgsConstructor;
-//import org.apache.kafka.clients.producer.ProducerConfig;
-//import org.apache.kafka.common.serialization.StringSerializer;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.kafka.annotation.EnableKafka;
-//import org.springframework.kafka.core.DefaultKafkaProducerFactory;
-//import org.springframework.kafka.core.KafkaTemplate;
-//import org.springframework.kafka.core.ProducerFactory;
-//import org.springframework.kafka.support.serializer.JsonSerializer;
-//
-//@RequiredArgsConstructor
-//@EnableKafka
-//@Configuration
-//public class KafkaProducerConfig {
-//
-//    private final KafkaProperties kafkaProperties;
-//
-//    // Kafka ProducerFactory를 생성하는 Bean 메서드
-//    @Bean
-//    public ProducerFactory<String, MessageDto> producerFactory() {
-//        return new DefaultKafkaProducerFactory<>(producerConfigurations());
-//    }
-//
-//    // Kafka Producer 구성을 위한 설정값들을 포함한 맵을 반환하는 메서드
-//    @Bean
-//    public Map<String, Object> producerConfigurations() {
-//        return ImmutableMap.<String, Object>builder()
-//                .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBroker())
-//                .put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
-//                .put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class)
-//                .build();
-//    }
-//
-//    // KafkaTemplate을 생성하는 Bean 메서드
-//    @Bean
-//    public KafkaTemplate<String, MessageDto> kafkaTemplate() {
-//        return new KafkaTemplate<>(producerFactory());
-//    }
-//
-//}
+package com.example.waggle.domain.chat.config.kafka;
+
+import com.example.waggle.web.dto.chat.ChatMessageDto;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@RequiredArgsConstructor
+@EnableKafka
+@Configuration
+public class KafkaProducerConfig {
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    public ProducerFactory<String, ChatMessageDto> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfigurations());
+    }
+
+    @Bean
+    public Map<String, Object> producerConfigurations() {
+        return ImmutableMap.<String, Object>builder()
+                .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBroker())
+                .put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                .put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class)
+                .build();
+    }
+
+    @Bean
+    public KafkaTemplate<String, ChatMessageDto> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+}

--- a/src/main/java/com/example/waggle/domain/chat/config/kafka/KafkaProperties.java
+++ b/src/main/java/com/example/waggle/domain/chat/config/kafka/KafkaProperties.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "kafka.waggle")
 public class KafkaProperties {
+
     private String topic;
     private String groupId;
     private String broker;
+
 }

--- a/src/main/java/com/example/waggle/domain/chat/service/ChatMessageListener.java
+++ b/src/main/java/com/example/waggle/domain/chat/service/ChatMessageListener.java
@@ -1,0 +1,20 @@
+package com.example.waggle.domain.chat.service;
+
+
+import com.example.waggle.web.dto.chat.ChatMessageDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ChatMessageListener {
+
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    @KafkaListener(topics = "waggle-chat", groupId = "chat-group")
+    public void receiveMessage(ChatMessageDto message) {
+        messagingTemplate.convertAndSend("/subscribe/" + message.getChatRoomId(), message);
+    }
+}

--- a/src/main/java/com/example/waggle/web/controller/ChatMessageController.java
+++ b/src/main/java/com/example/waggle/web/controller/ChatMessageController.java
@@ -8,6 +8,7 @@ import java.security.Principal;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -21,7 +22,8 @@ public class ChatMessageController {
     private final SimpMessageSendingOperations sendingOperations;
     private final MemberQueryService memberQueryService;
     private final ChatMessageCommandService chatMessageCommandService;
-
+    private final KafkaTemplate<String, ChatMessageDto> kafkaTemplate;
+    private final String KAFKA_TOPIC = "waggle-chat";
 
     @MessageMapping("/message")
     public void sendMessage(Principal principal, @Payload ChatMessageDto message) {
@@ -43,8 +45,9 @@ public class ChatMessageController {
             case TALK:
                 break;
         }
+
+        kafkaTemplate.send(KAFKA_TOPIC, message);
         chatMessageCommandService.createChatMessage(message);
-        sendingOperations.convertAndSend("/subscribe/" + message.getChatRoomId(), message);
     }
 
 }

--- a/src/main/resources/application-kafka.yml
+++ b/src/main/resources/application-kafka.yml
@@ -1,33 +1,16 @@
-#spring:
-#  kafka:
-#    producer:
-#      properties:
-#        min:
-#          insync:
-#            replicas: 2
-#kafka:
-#  bootstrapAddress: localhost:9092
-#  admin:
-#    properties:
-#  topic:
-#    alarm:
-#      name: alarm
-#      replicationFactor: 2
-#      numPartitions: 2
-#  consumer:
-#    alarm:
-#      rdb-group-id: createAlarmInRDB
-#      redis-group-id: publishInRedis
-#
-#    autoOffsetResetConfig: latest
-#  producer:
-#    acksConfig: all
-#    retry: 3
-#    enable-idempotence: true
-#    max-in-flight-requests-per-connection: 3
+spring:
+  kafka:
+    admin:
+      properties:
+        bootstrap.servers: localhost:9092
+    topic:
+      topics-to-create: waggle-chat
+      partitions: 6
+      replication-factor: 3
+
 
 kafka:
   waggle:
     topic: waggle-chat
-    groupId: waggle
+    groupId: waggle-chat-group
     broker: localhost:9092


### PR DESCRIPTION
## 🔎 Description
> 실시간 채팅 서비스의 메시지 브로커로 Apache Kafka를 사용했습니다.
### 🔎 주요 설정
- 파티션 수가 많을 수록 더 많은 소비자가 동시에 데이터를 처리할 수 있습니다.
- 복제 계수를 높게 설정하면, 브로커 장애가 발생해도 데이터의 안정성을 유지할 수 있습니다.
- 파티션 수는 6개, 복제계수는 3으로 설정했습니다.

추후 성능 최적화 작업을 할 때 파티션 수, 복제계수를 비롯하여 `batch.size`, `linger.ms`, `fetch.min.bytes` 등의 설정도 건드려봐도 좋을 것 같습니다.

## 🔗 Related Issue
- [https://github.com/teamWaggle/Waggle-server/issues/229](https://github.com/teamWaggle/Waggle-server/issues/229)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
