### PR TITLE
[Refactor/#246] refactor follow api by request from front end

### DIFF
--- a/src/main/java/com/example/waggle/domain/follow/application/FollowCommandService.java
+++ b/src/main/java/com/example/waggle/domain/follow/application/FollowCommandService.java
@@ -6,10 +6,10 @@ public interface FollowCommandService {
 
     Long follow(String from, String to);
 
-    Long follow(Member from, Long to);
+    Long follow(Member from, String to);
 
     void unFollow(String from, String to);
 
-    void unFollow(Member from, Long to);
+    void unFollow(Member from, String to);
 
 }

--- a/src/main/java/com/example/waggle/domain/follow/application/FollowCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/follow/application/FollowCommandServiceImpl.java
@@ -36,8 +36,8 @@ public class FollowCommandServiceImpl implements FollowCommandService {
     }
 
     @Override
-    public Long follow(Member from, Long to) {
-        Member followee = memberRepository.findById(to)
+    public Long follow(Member from, String to) {
+        Member followee = memberRepository.findByUserUrl(to)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
         validateFollowing(from, followee);
         Follow follow = buildFollow(from, followee);
@@ -61,8 +61,8 @@ public class FollowCommandServiceImpl implements FollowCommandService {
     }
 
     @Override
-    public void unFollow(Member from, Long to) {
-        Member followee = memberRepository.findById(to)
+    public void unFollow(Member from, String to) {
+        Member followee = memberRepository.findByUserUrl(to)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
         Follow follow = followRepository.findByToMemberAndFromMember(followee, from)
                 .orElseThrow(() -> new FollowHandler(ErrorStatus.FOLLOW_NOT_FOUND));

--- a/src/main/java/com/example/waggle/domain/follow/application/FollowQueryService.java
+++ b/src/main/java/com/example/waggle/domain/follow/application/FollowQueryService.java
@@ -1,6 +1,7 @@
 package com.example.waggle.domain.follow.application;
 
 import com.example.waggle.domain.follow.persistence.entity.Follow;
+import com.example.waggle.domain.member.persistence.entity.Member;
 
 import java.util.List;
 
@@ -16,4 +17,6 @@ public interface FollowQueryService {
     List<Follow> getFollowersByUsername(String username);
 
     List<Follow> getFollowersByUserUrl(String userUrl);
+
+    Boolean checkFollowing(Member member, String userUrl);
 }

--- a/src/main/java/com/example/waggle/domain/follow/application/FollowQueryService.java
+++ b/src/main/java/com/example/waggle/domain/follow/application/FollowQueryService.java
@@ -18,5 +18,5 @@ public interface FollowQueryService {
 
     List<Follow> getFollowersByUserUrl(String userUrl);
 
-    Boolean checkFollowing(Member member, String userUrl);
+    Boolean isFollowingMemberWithUserUrl(Member member, String userUrl);
 }

--- a/src/main/java/com/example/waggle/domain/follow/application/FollowQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/follow/application/FollowQueryServiceImpl.java
@@ -49,7 +49,7 @@ public class FollowQueryServiceImpl implements FollowQueryService {
     }
 
     @Override
-    public Boolean checkFollowing(Member member, String userUrl) {
+    public Boolean isFollowingMemberWithUserUrl(Member member, String userUrl) {
         return followRepository.existsFollowByFromMemberAndToMemberUserUrl(member, userUrl);
     }
 

--- a/src/main/java/com/example/waggle/domain/follow/application/FollowQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/follow/application/FollowQueryServiceImpl.java
@@ -1,7 +1,8 @@
 package com.example.waggle.domain.follow.application;
 
-import com.example.waggle.domain.follow.persistence.entity.Follow;
 import com.example.waggle.domain.follow.persistence.dao.FollowRepository;
+import com.example.waggle.domain.follow.persistence.entity.Follow;
+import com.example.waggle.domain.member.persistence.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -45,6 +46,11 @@ public class FollowQueryServiceImpl implements FollowQueryService {
     @Override
     public List<Follow> getFollowersByUserUrl(String userUrl) {
         return followRepository.findByToMember_UserUrl(userUrl);
+    }
+
+    @Override
+    public Boolean checkFollowing(Member member, String userUrl) {
+        return followRepository.existsFollowByFromMemberAndToMemberUserUrl(member, userUrl);
     }
 
 }

--- a/src/main/java/com/example/waggle/domain/follow/persistence/dao/FollowRepository.java
+++ b/src/main/java/com/example/waggle/domain/follow/persistence/dao/FollowRepository.java
@@ -32,4 +32,5 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     void deleteAllByFromMember(Member member);
 
+    Boolean existsFollowByFromMemberAndToMemberUserUrl(Member member, String userUrl);
 }

--- a/src/main/java/com/example/waggle/domain/follow/persistence/dao/FollowRepository.java
+++ b/src/main/java/com/example/waggle/domain/follow/persistence/dao/FollowRepository.java
@@ -32,5 +32,5 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     void deleteAllByFromMember(Member member);
 
-    Boolean existsFollowByFromMemberAndToMemberUserUrl(Member member, String userUrl);
+    boolean existsFollowByFromMemberAndToMemberUserUrl(Member member, String userUrl);
 }

--- a/src/main/java/com/example/waggle/domain/follow/persistence/entity/Follow.java
+++ b/src/main/java/com/example/waggle/domain/follow/persistence/entity/Follow.java
@@ -17,7 +17,7 @@ public class Follow extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "like_id")
+    @Column(name = "follow_id")
     private Long id;
 
     @NotNull

--- a/src/main/java/com/example/waggle/domain/follow/presentation/controller/FollowApiController.java
+++ b/src/main/java/com/example/waggle/domain/follow/presentation/controller/FollowApiController.java
@@ -6,10 +6,10 @@ import com.example.waggle.domain.follow.persistence.entity.Follow;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.member.presentation.converter.MemberConverter;
 import com.example.waggle.domain.member.presentation.dto.MemberResponse.MemberSummaryDto;
+import com.example.waggle.exception.payload.code.ErrorStatus;
+import com.example.waggle.exception.payload.dto.ApiResponseDto;
 import com.example.waggle.global.annotation.api.ApiErrorCodeExample;
 import com.example.waggle.global.annotation.auth.AuthUser;
-import com.example.waggle.exception.payload.dto.ApiResponseDto;
-import com.example.waggle.exception.payload.code.ErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,9 +36,9 @@ public class FollowApiController {
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
     @PostMapping("/follow")
-    public ApiResponseDto<Long> requestFollow(@RequestParam("toMemberId") Long toMemberId,
+    public ApiResponseDto<Long> requestFollow(@RequestParam("userUrl") String userUrl,
                                               @AuthUser Member member) {
-        Long follow = followCommandService.follow(member, toMemberId);
+        Long follow = followCommandService.follow(member, userUrl);
         return ApiResponseDto.onSuccess(follow);
     }
 
@@ -47,9 +47,9 @@ public class FollowApiController {
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
     @PostMapping("/unfollow")
-    public ApiResponseDto<Boolean> requestUnFollow(@RequestParam("toMemberId") Long toMemberId,
+    public ApiResponseDto<Boolean> requestUnFollow(@RequestParam("userUrl") String userUrl,
                                                    @AuthUser Member member) {
-        followCommandService.unFollow(member, toMemberId);
+        followCommandService.unFollow(member, userUrl);
         return ApiResponseDto.onSuccess(Boolean.TRUE);
     }
 

--- a/src/main/java/com/example/waggle/domain/follow/presentation/controller/FollowApiController.java
+++ b/src/main/java/com/example/waggle/domain/follow/presentation/controller/FollowApiController.java
@@ -78,4 +78,14 @@ public class FollowApiController {
                 .map(f -> MemberConverter.toMemberSummaryDto(f.getFromMember())).collect(Collectors.toList());
         return ApiResponseDto.onSuccess(collect);
     }
+
+    @Operation(summary = "상대방 팔로우 상태 확인 🔑", description = "조회하는 상대방을 팔로우하고 있는지 확인합니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
+    @GetMapping("/following/{userUrl}")
+    public ApiResponseDto<Boolean> checkFollowingTo(@PathVariable("userUrl") String userUrl,
+                                                    @AuthUser Member member) {
+        return ApiResponseDto.onSuccess(followQueryService.checkFollowing(member, userUrl));
+    }
 }

--- a/src/main/java/com/example/waggle/domain/follow/presentation/controller/FollowApiController.java
+++ b/src/main/java/com/example/waggle/domain/follow/presentation/controller/FollowApiController.java
@@ -53,18 +53,6 @@ public class FollowApiController {
         return ApiResponseDto.onSuccess(Boolean.TRUE);
     }
 
-    @Operation(summary = "유저 팔로잉 목록 조회", description = "로그인한 유저의 팔로잉 목록을 보여줍니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR
-    })
-    @GetMapping("/list/following")
-
-    public ApiResponseDto<List<MemberSummaryDto>> getFollowingMemberListByUsername(@AuthUser Member member) {
-        List<Follow> followings = followQueryService.getFollowingsByUsername(member.getUsername());
-        List<MemberSummaryDto> collect = followings.stream()
-                .map(f -> MemberConverter.toMemberSummaryDto(f.getToMember())).collect(Collectors.toList());
-        return ApiResponseDto.onSuccess(collect);
-    }
 
     @Operation(summary = "멤버 팔로잉 목록 조회", description = "조회한 멤버의 팔로잉 목록을 보여줍니다.")
     @ApiErrorCodeExample({
@@ -78,17 +66,6 @@ public class FollowApiController {
         return ApiResponseDto.onSuccess(collect);
     }
 
-    @Operation(summary = "유저 팔로워 목록 조회", description = "로그인한 유저의 팔로워 목록을 보여줍니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR
-    })
-    @GetMapping("/list/follower")
-    public ApiResponseDto<List<MemberSummaryDto>> getFollowerMemberListByUsername(@AuthUser Member member) {
-        List<Follow> followers = followQueryService.getFollowersByUsername(member.getUsername());
-        List<MemberSummaryDto> collect = followers.stream()
-                .map(f -> MemberConverter.toMemberSummaryDto(f.getFromMember())).collect(Collectors.toList());
-        return ApiResponseDto.onSuccess(collect);
-    }
 
     @Operation(summary = "멤버 팔로워 목록 조회", description = "조회한 멤버의 팔로워 목록을 보여줍니다.")
     @ApiErrorCodeExample({

--- a/src/main/java/com/example/waggle/domain/follow/presentation/controller/FollowApiController.java
+++ b/src/main/java/com/example/waggle/domain/follow/presentation/controller/FollowApiController.java
@@ -86,6 +86,6 @@ public class FollowApiController {
     @GetMapping("/following/{userUrl}")
     public ApiResponseDto<Boolean> checkFollowingTo(@PathVariable("userUrl") String userUrl,
                                                     @AuthUser Member member) {
-        return ApiResponseDto.onSuccess(followQueryService.checkFollowing(member, userUrl));
+        return ApiResponseDto.onSuccess(followQueryService.isFollowingMemberWithUserUrl(member, userUrl));
     }
 }

--- a/src/main/java/com/example/waggle/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/waggle/security/config/SecurityConfig.java
@@ -124,7 +124,8 @@ public class SecurityConfig {
                 antMatcher(HttpMethod.GET, "api/teams/{teamId}/participation"),
                 antMatcher(HttpMethod.GET, "api/teams/{teamId}/participation/status"),
                 antMatcher(HttpMethod.GET, "api/schedules/teams/{teamId}/auth"),
-                antMatcher(HttpMethod.GET, "api/schdules/teams/{teamId}/period/auth")
+                antMatcher(HttpMethod.GET, "api/schdules/teams/{teamId}/period/auth"),
+                antMatcher(HttpMethod.GET, "api/follows/following/{userUrl}")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }
@@ -155,7 +156,7 @@ public class SecurityConfig {
                 antMatcher(HttpMethod.GET, "/api/questions/**"),
                 antMatcher(HttpMethod.GET, "/api/sirens/**"),
                 antMatcher(HttpMethod.GET, "/api/recommends/{boardId}/memberList"),
-                antMatcher(HttpMethod.GET, "/api/follows/**"),
+                antMatcher(HttpMethod.GET, "/api/follows/list/**"),
                 antMatcher(HttpMethod.GET, "/api/chat/rooms/**"),
                 antMatcher("/ws/chat/**"),
                 antMatcher("/chat/**"),


### PR DESCRIPTION
## 🔎 Description
> refactor follow api by request from front end
1. 팔로우, 언팔로우 파라미터 변경
2. 조회 상대 팔로우 상태 확인 api 추가
3. 필요없는 api 지우기

## 🔗 Related Issue
- https://github.com/teamWaggle/Waggle-server/issues/246


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [x] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
