### PR TITLE
[Refactor/#251] combine sorting & filtering api of siren

### DIFF
--- a/src/main/java/com/example/waggle/domain/board/application/question/QuestionQueryService.java
+++ b/src/main/java/com/example/waggle/domain/board/application/question/QuestionQueryService.java
@@ -1,7 +1,7 @@
 package com.example.waggle.domain.board.application.question;
 
 import com.example.waggle.domain.board.persistence.entity.Question;
-import com.example.waggle.domain.board.presentation.dto.question.QuestionFilterParam;
+import com.example.waggle.domain.board.presentation.dto.question.QuestionSortParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -21,7 +21,7 @@ public interface QuestionQueryService {
 
     Page<Question> getPagedQuestions(Pageable pageable);
 
-    Page<Question> getPagedQuestionsByFilter(QuestionFilterParam filterParam, Pageable pageable);
+    Page<Question> getPagedQuestionsByFilter(QuestionSortParam sortParam, Pageable pageable);
 
     List<Question> getRepresentativeQuestionList();
 

--- a/src/main/java/com/example/waggle/domain/board/application/question/QuestionQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/board/application/question/QuestionQueryServiceImpl.java
@@ -2,7 +2,7 @@ package com.example.waggle.domain.board.application.question;
 
 import com.example.waggle.domain.board.persistence.dao.question.jpa.QuestionRepository;
 import com.example.waggle.domain.board.persistence.entity.Question;
-import com.example.waggle.domain.board.presentation.dto.question.QuestionFilterParam;
+import com.example.waggle.domain.board.presentation.dto.question.QuestionSortParam;
 import com.example.waggle.domain.recommend.persistence.dao.RecommendRepository;
 import com.example.waggle.exception.object.handler.QuestionHandler;
 import com.example.waggle.exception.payload.code.ErrorStatus;
@@ -62,8 +62,8 @@ public class QuestionQueryServiceImpl implements QuestionQueryService {
     }
 
     @Override
-    public Page<Question> getPagedQuestionsByFilter(QuestionFilterParam filterParam, Pageable pageable) {
-        return questionRepository.findQuestionsByFilter(filterParam, pageable);
+    public Page<Question> getPagedQuestionsByFilter(QuestionSortParam sortParam, Pageable pageable) {
+        return questionRepository.findQuestionsByFilter(sortParam, pageable);
     }
 
     @Override

--- a/src/main/java/com/example/waggle/domain/board/application/siren/SirenQueryService.java
+++ b/src/main/java/com/example/waggle/domain/board/application/siren/SirenQueryService.java
@@ -3,6 +3,7 @@ package com.example.waggle.domain.board.application.siren;
 import com.example.waggle.domain.board.persistence.entity.Siren;
 import com.example.waggle.domain.board.persistence.entity.SirenCategory;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenFilterParam;
+import com.example.waggle.domain.board.presentation.dto.siren.SirenSortParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -21,9 +22,11 @@ public interface SirenQueryService {
 
     Page<Siren> getPagedSirenListByMemberId(Long memberId, Pageable pageable);
 
-    Page<Siren> getPagedSirenListByFilter(SirenFilterParam filterParam, Pageable pageable);
+    Page<Siren> getPagedSirenListByFilter(SirenSortParam filterParam, Pageable pageable);
 
     Page<Siren> getPagedSirenListByCategory(SirenCategory category, Pageable pageable);
+
+    Page<Siren> getPagedSirenListByFilterAndSort(SirenFilterParam filterParam, SirenSortParam sortParam, Pageable pageable);
 
     Siren getSirenByBoardId(Long boardId);
 

--- a/src/main/java/com/example/waggle/domain/board/application/siren/SirenQueryService.java
+++ b/src/main/java/com/example/waggle/domain/board/application/siren/SirenQueryService.java
@@ -1,7 +1,6 @@
 package com.example.waggle.domain.board.application.siren;
 
 import com.example.waggle.domain.board.persistence.entity.Siren;
-import com.example.waggle.domain.board.persistence.entity.SirenCategory;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenFilterParam;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenSortParam;
 import org.springframework.data.domain.Page;
@@ -21,10 +20,6 @@ public interface SirenQueryService {
     Page<Siren> getPagedSirenListByUserUrl(String userUrl, Pageable pageable);
 
     Page<Siren> getPagedSirenListByMemberId(Long memberId, Pageable pageable);
-
-    Page<Siren> getPagedSirenListByFilter(SirenSortParam filterParam, Pageable pageable);
-
-    Page<Siren> getPagedSirenListByCategory(SirenCategory category, Pageable pageable);
 
     Page<Siren> getPagedSirenListByFilterAndSort(SirenFilterParam filterParam, SirenSortParam sortParam, Pageable pageable);
 

--- a/src/main/java/com/example/waggle/domain/board/application/siren/SirenQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/board/application/siren/SirenQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.waggle.domain.board.persistence.entity.ResolutionStatus;
 import com.example.waggle.domain.board.persistence.entity.Siren;
 import com.example.waggle.domain.board.persistence.entity.SirenCategory;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenFilterParam;
+import com.example.waggle.domain.board.presentation.dto.siren.SirenSortParam;
 import com.example.waggle.domain.recommend.persistence.dao.RecommendRepository;
 import com.example.waggle.exception.object.handler.SirenHandler;
 import com.example.waggle.exception.payload.code.ErrorStatus;
@@ -71,13 +72,18 @@ public class SirenQueryServiceImpl implements SirenQueryService {
     }
 
     @Override
-    public Page<Siren> getPagedSirenListByFilter(SirenFilterParam filterParam, Pageable pageable) {
+    public Page<Siren> getPagedSirenListByFilter(SirenSortParam filterParam, Pageable pageable) {
         return sirenRepository.findSirensByFilter(filterParam, pageable);
     }
 
     @Override
     public Page<Siren> getPagedSirenListByCategory(SirenCategory category, Pageable pageable) {
         return sirenRepository.findByCategory(category, pageable);
+    }
+
+    @Override
+    public Page<Siren> getPagedSirenListByFilterAndSort(SirenFilterParam filterParam, SirenSortParam sortParam, Pageable pageable) {
+        return sirenRepository.findSirensByFilterAndSort(filterParam, sortParam, pageable);
     }
 
     @Override

--- a/src/main/java/com/example/waggle/domain/board/application/siren/SirenQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/board/application/siren/SirenQueryServiceImpl.java
@@ -3,7 +3,6 @@ package com.example.waggle.domain.board.application.siren;
 import com.example.waggle.domain.board.persistence.dao.siren.jpa.SirenRepository;
 import com.example.waggle.domain.board.persistence.entity.ResolutionStatus;
 import com.example.waggle.domain.board.persistence.entity.Siren;
-import com.example.waggle.domain.board.persistence.entity.SirenCategory;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenFilterParam;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenSortParam;
 import com.example.waggle.domain.recommend.persistence.dao.RecommendRepository;
@@ -69,16 +68,6 @@ public class SirenQueryServiceImpl implements SirenQueryService {
     @Override
     public Page<Siren> getPagedSirenListByMemberId(Long memberId, Pageable pageable) {
         return sirenRepository.findByMemberId(memberId, pageable);
-    }
-
-    @Override
-    public Page<Siren> getPagedSirenListByFilter(SirenSortParam filterParam, Pageable pageable) {
-        return sirenRepository.findSirensByFilter(filterParam, pageable);
-    }
-
-    @Override
-    public Page<Siren> getPagedSirenListByCategory(SirenCategory category, Pageable pageable) {
-        return sirenRepository.findByCategory(category, pageable);
     }
 
     @Override

--- a/src/main/java/com/example/waggle/domain/board/persistence/dao/question/querydsl/QuestionQueryRepository.java
+++ b/src/main/java/com/example/waggle/domain/board/persistence/dao/question/querydsl/QuestionQueryRepository.java
@@ -1,10 +1,10 @@
 package com.example.waggle.domain.board.persistence.dao.question.querydsl;
 
 import com.example.waggle.domain.board.persistence.entity.Question;
-import com.example.waggle.domain.board.presentation.dto.question.QuestionFilterParam;
+import com.example.waggle.domain.board.presentation.dto.question.QuestionSortParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface QuestionQueryRepository {
-    Page<Question> findQuestionsByFilter(QuestionFilterParam filterParam, Pageable pageable);
+    Page<Question> findQuestionsByFilter(QuestionSortParam sortParam, Pageable pageable);
 }

--- a/src/main/java/com/example/waggle/domain/board/persistence/dao/question/querydsl/QuestionQueryRepositoryImpl.java
+++ b/src/main/java/com/example/waggle/domain/board/persistence/dao/question/querydsl/QuestionQueryRepositoryImpl.java
@@ -25,7 +25,7 @@ public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
     @Override
     public Page<Question> findQuestionsByFilter(QuestionFilterParam filterParam, Pageable pageable) {
         JPAQuery<Question> baseQuery = query.selectFrom(question);
-        if (filterParam == QuestionFilterParam.recommend) {
+        if (filterParam == QuestionFilterParam.RECOMMEND) {
             baseQuery.leftJoin(recommend).on(recommend.board.eq(question._super));
             baseQuery.groupBy(question);
         }
@@ -45,22 +45,22 @@ public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
 
     private OrderSpecifier[] createOrderFilter(QuestionFilterParam filterParam) {
         switch (filterParam) {
-            case latest -> {
+            case LATEST -> {
                 return new OrderSpecifier[]{question.createdDate.desc()};
             }
-            case recommend -> {
+            case RECOMMEND -> {
                 return new OrderSpecifier[]{
                         recommend.count().desc(),
                         question.createdDate.desc()
                 };
             }
-            case resolved -> {
+            case RESOLVED -> {
                 return new OrderSpecifier[]{
                         question.status.asc(),
                         question.createdDate.desc()
                 };
             }
-            case unresolved -> {
+            case UNRESOLVED -> {
                 return new OrderSpecifier[]{
                         question.status.desc(),
                         question.createdDate.desc()

--- a/src/main/java/com/example/waggle/domain/board/persistence/dao/question/querydsl/QuestionQueryRepositoryImpl.java
+++ b/src/main/java/com/example/waggle/domain/board/persistence/dao/question/querydsl/QuestionQueryRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.example.waggle.domain.board.persistence.dao.question.querydsl;
 
 import com.example.waggle.domain.board.persistence.entity.Question;
-import com.example.waggle.domain.board.presentation.dto.question.QuestionFilterParam;
+import com.example.waggle.domain.board.presentation.dto.question.QuestionSortParam;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -23,14 +23,14 @@ public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
     private final JPAQueryFactory query;
 
     @Override
-    public Page<Question> findQuestionsByFilter(QuestionFilterParam filterParam, Pageable pageable) {
+    public Page<Question> findQuestionsByFilter(QuestionSortParam sortParam, Pageable pageable) {
         JPAQuery<Question> baseQuery = query.selectFrom(question);
-        if (filterParam == QuestionFilterParam.RECOMMEND) {
+        if (sortParam == QuestionSortParam.RECOMMEND) {
             baseQuery.leftJoin(recommend).on(recommend.board.eq(question._super));
             baseQuery.groupBy(question);
         }
         List<Question> questionList = baseQuery
-                .orderBy(createOrderFilter(filterParam))
+                .orderBy(createSortingOrder(sortParam))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -43,8 +43,8 @@ public class QuestionQueryRepositoryImpl implements QuestionQueryRepository {
         return new PageImpl<>(questionList, pageable, count);
     }
 
-    private OrderSpecifier[] createOrderFilter(QuestionFilterParam filterParam) {
-        switch (filterParam) {
+    private OrderSpecifier[] createSortingOrder(QuestionSortParam sortParam) {
+        switch (sortParam) {
             case LATEST -> {
                 return new OrderSpecifier[]{question.createdDate.desc()};
             }

--- a/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepository.java
+++ b/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepository.java
@@ -1,14 +1,18 @@
 package com.example.waggle.domain.board.persistence.dao.siren.querydsl;
 
 import com.example.waggle.domain.board.persistence.entity.Siren;
+import com.example.waggle.domain.board.persistence.entity.SirenCategory;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenFilterParam;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface SirenQueryRepository {
 
     Page<Siren> findSirensByFilter(SirenFilterParam filterParam, Pageable pageable);
+
+    Page<Siren> findSirensByFilterAndSort(SirenFilterParam filterParam, SirenCategory category, Pageable pageable);
 
     List<Siren> findRandomUnresolvedSirens();
 

--- a/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepository.java
+++ b/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepository.java
@@ -10,8 +10,6 @@ import java.util.List;
 
 public interface SirenQueryRepository {
 
-    Page<Siren> findSirensByFilter(SirenSortParam filterParam, Pageable pageable);
-
     Page<Siren> findSirensByFilterAndSort(SirenFilterParam filterParam, SirenSortParam sortParam, Pageable pageable);
 
     List<Siren> findRandomUnresolvedSirens();

--- a/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepository.java
+++ b/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepository.java
@@ -1,8 +1,8 @@
 package com.example.waggle.domain.board.persistence.dao.siren.querydsl;
 
 import com.example.waggle.domain.board.persistence.entity.Siren;
-import com.example.waggle.domain.board.persistence.entity.SirenCategory;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenFilterParam;
+import com.example.waggle.domain.board.presentation.dto.siren.SirenSortParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,9 +10,9 @@ import java.util.List;
 
 public interface SirenQueryRepository {
 
-    Page<Siren> findSirensByFilter(SirenFilterParam filterParam, Pageable pageable);
+    Page<Siren> findSirensByFilter(SirenSortParam filterParam, Pageable pageable);
 
-    Page<Siren> findSirensByFilterAndSort(SirenFilterParam filterParam, SirenCategory category, Pageable pageable);
+    Page<Siren> findSirensByFilterAndSort(SirenFilterParam filterParam, SirenSortParam sortParam, Pageable pageable);
 
     List<Siren> findRandomUnresolvedSirens();
 

--- a/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepositoryImpl.java
+++ b/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepositoryImpl.java
@@ -28,7 +28,7 @@ public class SirenQueryRepositoryImpl implements SirenQueryRepository {
     @Override
     public Page<Siren> findSirensByFilterAndSort(SirenFilterParam filterParam, SirenSortParam sortParam, Pageable pageable) {
         JPAQuery<Siren> baseQuery = query.selectFrom(siren);
-        if (sortParam.equals(SirenSortParam.recommend)) {
+        if (sortParam.equals(SirenSortParam.RECOMMEND)) {
             baseQuery.leftJoin(recommend).on(siren._super.eq(recommend.board));
             baseQuery.groupBy(siren);
         }
@@ -55,19 +55,19 @@ public class SirenQueryRepositoryImpl implements SirenQueryRepository {
 
     private OrderSpecifier[] createSortingOrder(SirenSortParam sortParam) {
         switch (sortParam) {
-            case recommend -> {
+            case RECOMMEND -> {
                 return new OrderSpecifier[]{
                         recommend.count().desc(),
                         siren.createdDate.desc()
                 };
             }
-            case resolved -> {
+            case RESOLVED -> {
                 return new OrderSpecifier[]{
                         siren.status.asc(),
                         siren.createdDate.desc()
                 };
             }
-            case unresolved -> {
+            case UNRESOLVED -> {
                 return new OrderSpecifier[]{
                         siren.status.desc(),
                         siren.createdDate.desc()

--- a/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepositoryImpl.java
+++ b/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepositoryImpl.java
@@ -27,24 +27,6 @@ public class SirenQueryRepositoryImpl implements SirenQueryRepository {
     private final JPAQueryFactory query;
 
     @Override
-    public Page<Siren> findSirensByFilter(SirenSortParam sortParam, Pageable pageable) {
-        JPAQuery<Siren> baseQuery = query.selectFrom(siren);
-        if (sortParam.equals(SirenSortParam.recommend)) {
-            baseQuery.leftJoin(recommend).on(siren._super.eq(recommend.board));
-            baseQuery.groupBy(siren);
-        }
-        List<Siren> sirenList = baseQuery
-                .orderBy(createSortingOrder(sortParam))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
-        Long count = query.select(siren.count())
-                .from(siren)
-                .fetchOne();
-        return new PageImpl<>(sirenList, pageable, count);
-    }
-
-    @Override
     public Page<Siren> findSirensByFilterAndSort(SirenFilterParam filterParam, SirenSortParam sortParam, Pageable pageable) {
         JPAQuery<Siren> baseQuery = query.selectFrom(siren);
         if (sortParam.equals(SirenSortParam.recommend)) {

--- a/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepositoryImpl.java
+++ b/src/main/java/com/example/waggle/domain/board/persistence/dao/siren/querydsl/SirenQueryRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.example.waggle.domain.board.persistence.dao.siren.querydsl;
 
 import com.example.waggle.domain.board.persistence.entity.ResolutionStatus;
 import com.example.waggle.domain.board.persistence.entity.Siren;
-import com.example.waggle.domain.board.persistence.entity.SirenCategory;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenFilterParam;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenSortParam;
 import com.querydsl.core.types.OrderSpecifier;
@@ -81,25 +80,6 @@ public class SirenQueryRepositoryImpl implements SirenQueryRepository {
     }
 
     private BooleanExpression selectCategory(SirenFilterParam filterParam) {
-        switch (filterParam) {
-            case ALL -> {
-                return null;
-            }
-            case ETC -> {
-                return siren.category.eq(SirenCategory.ETC);
-            }
-            case PROTECT -> {
-                return siren.category.eq(SirenCategory.PROTECT);
-            }
-            case FIND_PET -> {
-                return siren.category.eq(SirenCategory.FIND_PET);
-            }
-            case FIND_OWNER -> {
-                return siren.category.eq(SirenCategory.FIND_OWNER);
-            }
-            default -> {
-                return null;
-            }
-        }
+        return filterParam == SirenFilterParam.ALL ? null : siren.category.eq(filterParam.getCategory());
     }
 }

--- a/src/main/java/com/example/waggle/domain/board/presentation/controller/QuestionApiController.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/controller/QuestionApiController.java
@@ -5,17 +5,17 @@ import com.example.waggle.domain.board.application.question.QuestionCommandServi
 import com.example.waggle.domain.board.application.question.QuestionQueryService;
 import com.example.waggle.domain.board.persistence.entity.Question;
 import com.example.waggle.domain.board.presentation.converter.QuestionConverter;
-import com.example.waggle.domain.board.presentation.dto.question.QuestionFilterParam;
 import com.example.waggle.domain.board.presentation.dto.question.QuestionRequest;
 import com.example.waggle.domain.board.presentation.dto.question.QuestionResponse.QuestionSummaryDto;
 import com.example.waggle.domain.board.presentation.dto.question.QuestionResponse.QuestionSummaryListDto;
 import com.example.waggle.domain.board.presentation.dto.question.QuestionResponse.RepresentativeQuestionDto;
+import com.example.waggle.domain.board.presentation.dto.question.QuestionSortParam;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.recommend.application.query.RecommendQueryService;
+import com.example.waggle.exception.payload.code.ErrorStatus;
+import com.example.waggle.exception.payload.dto.ApiResponseDto;
 import com.example.waggle.global.annotation.api.ApiErrorCodeExample;
 import com.example.waggle.global.annotation.auth.AuthUser;
-import com.example.waggle.exception.payload.dto.ApiResponseDto;
-import com.example.waggle.exception.payload.code.ErrorStatus;
 import com.example.waggle.global.util.MediaUtil;
 import com.example.waggle.global.util.PageUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -107,16 +107,16 @@ public class QuestionApiController {
         return ApiResponseDto.onSuccess(listDto);
     }
 
-    @Operation(summary = "질문 필터 조회", description = "필터 옵션에 맞추어 결과를 조회합니다.")
+    @Operation(summary = "질문 정렬 조회", description = "필터 옵션에 맞추어 결과를 조회합니다.")
     @ApiErrorCodeExample({
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    @GetMapping("/filter")
-    public ApiResponseDto<QuestionSummaryListDto> getQuestionsByFilterParam(
-            @RequestParam(name = "filterParam") QuestionFilterParam filterParam,
+    @GetMapping("/sort")
+    public ApiResponseDto<QuestionSummaryListDto> getQuestionsBySortParam(
+            @RequestParam(name = "filterParam") QuestionSortParam sortParam,
             @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
         Pageable pageable = PageRequest.of(currentPage, PageUtil.QUESTION_SIZE);
-        Page<Question> questions = questionQueryService.getPagedQuestionsByFilter(filterParam, pageable);
+        Page<Question> questions = questionQueryService.getPagedQuestionsByFilter(sortParam, pageable);
         QuestionSummaryListDto listDto = QuestionConverter.toListDto(questions);
         setRecommendCntInList(listDto.getQuestionList());
         return ApiResponseDto.onSuccess(listDto);

--- a/src/main/java/com/example/waggle/domain/board/presentation/controller/SirenApiController.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/controller/SirenApiController.java
@@ -4,7 +4,6 @@ import com.example.waggle.domain.board.application.siren.SirenCacheService;
 import com.example.waggle.domain.board.application.siren.SirenCommandService;
 import com.example.waggle.domain.board.application.siren.SirenQueryService;
 import com.example.waggle.domain.board.persistence.entity.Siren;
-import com.example.waggle.domain.board.persistence.entity.SirenCategory;
 import com.example.waggle.domain.board.presentation.converter.SirenConverter;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenFilterParam;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenRequest;
@@ -114,36 +113,6 @@ public class SirenApiController {
             @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
         Pageable pageable = PageRequest.of(currentPage, 8, latestSorting);
         Page<Siren> pagedSirenList = sirenQueryService.getPagedSirenList(pageable);
-        SirenPagedSummaryListDto listDto = SirenConverter.toSirenPageDto(pagedSirenList);
-        setRecommendCntInList(listDto.getSirenList());
-        return ApiResponseDto.onSuccess(listDto);
-    }
-
-    @Operation(summary = "사이렌 필터 조회", description = "필터 옵션에 맞추어 결과를 조회합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR
-    })
-    @GetMapping("/filter")
-    public ApiResponseDto<SirenPagedSummaryListDto> getSirensByFilter(
-            @RequestParam(name = "filterParam") SirenSortParam filterParam,
-            @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
-        Pageable pageable = PageRequest.of(currentPage, SIREN_SIZE);
-        Page<Siren> pagedSirenList = sirenQueryService.getPagedSirenListByFilter(filterParam, pageable);
-        SirenPagedSummaryListDto listDto = SirenConverter.toSirenPageDto(pagedSirenList);
-        setRecommendCntInList(listDto.getSirenList());
-        return ApiResponseDto.onSuccess(listDto);
-    }
-
-    @Operation(summary = "사이렌 카테고리 조회", description = "카테고리 옵션에 맞추어 결과를 조회합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR
-    })
-    @GetMapping("/category")
-    public ApiResponseDto<SirenPagedSummaryListDto> getSirensByCategory(
-            @RequestParam(name = "category") SirenCategory category,
-            @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
-        Pageable pageable = PageRequest.of(currentPage, SIREN_SIZE, latestSorting);
-        Page<Siren> pagedSirenList = sirenQueryService.getPagedSirenListByCategory(category, pageable);
         SirenPagedSummaryListDto listDto = SirenConverter.toSirenPageDto(pagedSirenList);
         setRecommendCntInList(listDto.getSirenList());
         return ApiResponseDto.onSuccess(listDto);

--- a/src/main/java/com/example/waggle/domain/board/presentation/dto/question/QuestionFilterParam.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/dto/question/QuestionFilterParam.java
@@ -1,5 +1,5 @@
 package com.example.waggle.domain.board.presentation.dto.question;
 
 public enum QuestionFilterParam {
-    resolved, unresolved, recommend, latest;
+    RESOLVED, UNRESOLVED, RECOMMEND, LATEST;
 }

--- a/src/main/java/com/example/waggle/domain/board/presentation/dto/question/QuestionSortParam.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/dto/question/QuestionSortParam.java
@@ -1,5 +1,5 @@
 package com.example.waggle.domain.board.presentation.dto.question;
 
-public enum QuestionFilterParam {
+public enum QuestionSortParam {
     RESOLVED, UNRESOLVED, RECOMMEND, LATEST;
 }

--- a/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenFilterParam.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenFilterParam.java
@@ -1,5 +1,5 @@
 package com.example.waggle.domain.board.presentation.dto.siren;
 
 public enum SirenFilterParam {
-    resolved, unresolved, recommend, latest;
+    FIND_PET, FIND_OWNER, PROTECT, ETC, ALL
 }

--- a/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenFilterParam.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenFilterParam.java
@@ -1,5 +1,20 @@
 package com.example.waggle.domain.board.presentation.dto.siren;
 
+import com.example.waggle.domain.board.persistence.entity.SirenCategory;
+import lombok.Getter;
+
+@Getter
 public enum SirenFilterParam {
-    FIND_PET, FIND_OWNER, PROTECT, ETC, ALL
+    FIND_PET(SirenCategory.FIND_PET),
+    FIND_OWNER(SirenCategory.FIND_OWNER),
+    PROTECT(SirenCategory.PROTECT),
+    ETC(SirenCategory.ETC),
+    ALL(null);
+
+    private final SirenCategory category;
+
+    SirenFilterParam(SirenCategory category) {
+        this.category = category;
+    }
+
 }

--- a/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenSortParam.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenSortParam.java
@@ -1,5 +1,5 @@
 package com.example.waggle.domain.board.presentation.dto.siren;
 
 public enum SirenSortParam {
-    resolved, unresolved, recommend, latest;
+    RESOLVED, UNRESOLVED, RECOMMEND, LATEST;
 }

--- a/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenSortParam.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenSortParam.java
@@ -1,0 +1,5 @@
+package com.example.waggle.domain.board.presentation.dto.siren;
+
+public enum SirenSortParam {
+    resolved, unresolved, recommend, latest;
+}


### PR DESCRIPTION
## 🔎 Description
> combine sorting & filtering api of siren
1. QueryDsl을 통해 정렬과 필터링 통합
2. 컨트롤러에서 각 파라미터 받기
3. filterParam과 sortParam dto(enum) 생성


## 🔗 Related Issue
- https://github.com/teamWaggle/Waggle-server/issues/251


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [x] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
