### PR TITLE
[Refactor/#266] add sync logic in get memberlist who recommend board

### DIFF
--- a/src/main/java/com/example/waggle/domain/recommend/application/query/RecommendQueryService.java
+++ b/src/main/java/com/example/waggle/domain/recommend/application/query/RecommendQueryService.java
@@ -1,7 +1,6 @@
 package com.example.waggle.domain.recommend.application.query;
 
 import com.example.waggle.domain.member.persistence.entity.Member;
-import com.example.waggle.domain.recommend.presentation.dto.RecommendResponse.RecommendationInfo;
 
 import java.util.List;
 
@@ -13,6 +12,5 @@ public interface RecommendQueryService {
 
     List<Member> getRecommendingMembers(Long boardId);
 
-    RecommendationInfo getRecommendationInfo(Long boardId, String username);
 
 }

--- a/src/main/java/com/example/waggle/domain/recommend/application/query/RecommendQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/recommend/application/query/RecommendQueryServiceImpl.java
@@ -6,7 +6,6 @@ import com.example.waggle.domain.member.persistence.dao.MemberRepository;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.recommend.persistence.dao.RecommendRepository;
 import com.example.waggle.domain.recommend.persistence.entity.Recommend;
-import com.example.waggle.domain.recommend.presentation.dto.RecommendResponse.RecommendationInfo;
 import com.example.waggle.exception.object.general.GeneralException;
 import com.example.waggle.exception.object.handler.MemberHandler;
 import com.example.waggle.exception.payload.code.ErrorStatus;
@@ -51,14 +50,6 @@ public class RecommendQueryServiceImpl implements RecommendQueryService {
     public List<Member> getRecommendingMembers(Long boardId) {
         List<Recommend> byBoardId = recommendRepository.findByBoardId(boardId);
         return byBoardId.stream().map(r -> r.getMember()).collect(Collectors.toList());
-    }
-
-    @Override
-    public RecommendationInfo getRecommendationInfo(Long boardId, String username) {
-        return RecommendationInfo.builder()
-                .isRecommend(checkRecommend(boardId, username))
-                .recommendCount(countRecommend(boardId))
-                .build();
     }
 
 

--- a/src/main/java/com/example/waggle/domain/recommend/application/query/RecommendQueryServiceImplV2.java
+++ b/src/main/java/com/example/waggle/domain/recommend/application/query/RecommendQueryServiceImplV2.java
@@ -3,7 +3,6 @@ package com.example.waggle.domain.recommend.application.query;
 import com.example.waggle.domain.member.persistence.dao.MemberRepository;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.recommend.persistence.dao.RecommendRepository;
-import com.example.waggle.domain.recommend.presentation.dto.RecommendResponse;
 import com.example.waggle.exception.object.handler.MemberHandler;
 import com.example.waggle.exception.payload.code.ErrorStatus;
 import com.example.waggle.global.service.redis.RedisService;
@@ -13,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -57,19 +55,8 @@ public class RecommendQueryServiceImplV2 implements RecommendQueryService {
 
     @Override
     public List<Member> getRecommendingMembers(Long boardId) {
-        List<Member> fromRDB = recommendRepository.findByBoardId(boardId).stream()
+        return recommendRepository.findByBoardId(boardId).stream()
                 .map(recommend -> recommend.getMember()).collect(Collectors.toList());
-        List<Member> fromRedis = redisService.getAllRecommendingMemberList().stream()
-                .filter(memberId -> redisService.existRecommend(memberId, boardId))
-                .map(memberRepository::findById)
-                .filter(Optional::isPresent)
-                .map(Optional::get).collect(Collectors.toList());
-        fromRDB.addAll(fromRedis);
-        return fromRDB;
     }
 
-    @Override
-    public RecommendResponse.RecommendationInfo getRecommendationInfo(Long boardId, String username) {
-        return null;
-    }
 }

--- a/src/main/java/com/example/waggle/domain/recommend/presentation/controller/RecommendApiController.java
+++ b/src/main/java/com/example/waggle/domain/recommend/presentation/controller/RecommendApiController.java
@@ -6,10 +6,10 @@ import com.example.waggle.domain.member.presentation.dto.MemberResponse.MemberSu
 import com.example.waggle.domain.recommend.application.command.RecommendCommandService;
 import com.example.waggle.domain.recommend.application.query.RecommendQueryService;
 import com.example.waggle.domain.recommend.application.sync.RecommendSyncService;
+import com.example.waggle.exception.payload.code.ErrorStatus;
+import com.example.waggle.exception.payload.dto.ApiResponseDto;
 import com.example.waggle.global.annotation.api.ApiErrorCodeExample;
 import com.example.waggle.global.annotation.auth.AuthUser;
-import com.example.waggle.exception.payload.dto.ApiResponseDto;
-import com.example.waggle.exception.payload.code.ErrorStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -47,6 +47,7 @@ public class RecommendApiController {
     })
     @GetMapping("/{boardId}/memberList")
     public ApiResponseDto<MemberSummaryListDto> getRecommendingMembers(@PathVariable("boardId") Long boardId) {
+        recommendSyncService.syncRecommendation();
         List<Member> recommendingMembers = recommendQueryService.getRecommendingMembers(boardId);
         return ApiResponseDto.onSuccess(MemberConverter.toMemberListDto(recommendingMembers));
     }

--- a/src/main/java/com/example/waggle/global/service/redis/RedisService.java
+++ b/src/main/java/com/example/waggle/global/service/redis/RedisService.java
@@ -151,13 +151,12 @@ public class RedisService {
                 .map(board -> Long.valueOf(board)).collect(Collectors.toList());
     }
 
-//    public List<Long> getRecommendingMemberList(Long boardId) {
-//            SetOperations<String, String> setOperations = redisTemplate.opsForSet();
-//            String key = recommendBoardKeyPrefix + boardId;
-//            Set<String> members = setOperations.members(key);
-//        return members.stream()
-//                .map(member -> Long.valueOf(member)).collect(Collectors.toList());
-//    }
+    public List<Long> getAllInitMemberList() {
+        Set<String> keysByPattern = getKeysByPattern(initKeyPrefix + "*");
+        return keysByPattern.stream()
+                .map(key -> Long.valueOf(key.substring(initKeyPrefix.length())))
+                .collect(Collectors.toList());
+    }
 
     public List<Long> getAllRecommendingMemberList() {
         Set<String> keysByPattern = getKeysByPattern(recommendMemberKeyPrefix + "*");


### PR DESCRIPTION
## 🔎 Description
> bug fix : 좋아요 목록 조회 시 중복 조회

* 발생 원인 : rdb와 redis를 조회하는데, 인증 후 좋아요 철회 -> 좋아요 클릭 시 rdb와 redis 동시에 값이 존재
* 해결 1차 : rdb 우선 체크, redis 조회 시 중복 멤버 삭제
* 1차 해결 문제 발생 : 좋아요 철회 반영 x
* 해결 2차 : sync -> 좋아요 목록 조회

아쉬운 점 : sync가 너무 자주 발생하게 되는 것 아닌가 한다. 하지만 이게 고안한 방법 중엔 가장 덜 복잡했다.(나머지는 구현가능성도 떨어짐)

-> sync가 자주 발생하면 안좋은가? 에 대한 대답은 애매한 것 같다. 캐싱이 있으면 좋지만 없다고 속도측면에서 엄청난 부하를 일으키는 것이 아니기 때문이다. 오히려 개선을 위한 기술이다. 생성의 의의가 떨어지는 방식이라 약간 아쉬운 것같다.


## 🔗 Related Issue
- https://github.com/teamWaggle/Waggle-server/issues/266


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [x] ♻️ Code Refactor
- [x] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
