### PR TITLE
[Refactor/#281] refactor comment api

### DIFF
--- a/src/main/java/com/example/waggle/domain/board/presentation/converter/QuestionConverter.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/converter/QuestionConverter.java
@@ -5,9 +5,9 @@ import com.example.waggle.domain.board.presentation.dto.question.QuestionRespons
 import com.example.waggle.domain.board.presentation.dto.question.QuestionResponse.QuestionSummaryDto;
 import com.example.waggle.domain.board.presentation.dto.question.QuestionResponse.QuestionSummaryListDto;
 import com.example.waggle.domain.board.presentation.dto.question.QuestionResponse.RepresentativeQuestionDto;
+import com.example.waggle.domain.member.presentation.converter.MemberConverter;
 import com.example.waggle.global.util.MediaUtil;
 import com.example.waggle.global.util.PageUtil;
-import com.example.waggle.domain.member.presentation.converter.MemberConverter;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -49,6 +49,7 @@ public class QuestionConverter {
                 .mediaList(MediaUtil.getBoardMedias(question))
                 .member(MemberConverter.toMemberSummaryDto(question.getMember()))
                 .viewCount(question.getViewCount())
+                .commentCount(question.getComments().size())
                 .build();
     }
 

--- a/src/main/java/com/example/waggle/domain/board/presentation/converter/SirenConverter.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/converter/SirenConverter.java
@@ -1,12 +1,12 @@
 package com.example.waggle.domain.board.presentation.converter;
 
 import com.example.waggle.domain.board.persistence.entity.Siren;
-import com.example.waggle.domain.board.presentation.dto.siren.SirenResponse.SirenSummaryListDto;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenResponse.SirenDetailDto;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenResponse.SirenPagedSummaryListDto;
 import com.example.waggle.domain.board.presentation.dto.siren.SirenResponse.SirenSummaryDto;
-import com.example.waggle.global.util.MediaUtil;
+import com.example.waggle.domain.board.presentation.dto.siren.SirenResponse.SirenSummaryListDto;
 import com.example.waggle.domain.member.presentation.converter.MemberConverter;
+import com.example.waggle.global.util.MediaUtil;
 import com.example.waggle.global.util.PageUtil;
 import org.springframework.data.domain.Page;
 
@@ -53,6 +53,7 @@ public class SirenConverter {
                 .status(siren.getStatus())
                 .member(MemberConverter.toMemberSummaryDto(siren.getMember()))
                 .viewCount(siren.getViewCount())
+                .commentCount(siren.getComments().size())
                 .build();
     }
 

--- a/src/main/java/com/example/waggle/domain/board/presentation/dto/question/QuestionResponse.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/dto/question/QuestionResponse.java
@@ -54,6 +54,7 @@ public class QuestionResponse {
         private MemberSummaryDto member;
         private int recommendCount;
         private long viewCount;
+        private int commentCount;
     }
 
     @Data

--- a/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenResponse.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenResponse.java
@@ -54,6 +54,7 @@ public class SirenResponse {
         private ResolutionStatus status;
         private int recommendCount;
         private long viewCount;
+        private int commentCount;
     }
 
     @Data

--- a/src/main/java/com/example/waggle/domain/conversation/presentation/controller/CommentApiController.java
+++ b/src/main/java/com/example/waggle/domain/conversation/presentation/controller/CommentApiController.java
@@ -1,5 +1,6 @@
 package com.example.waggle.domain.conversation.presentation.controller;
 
+import com.example.waggle.domain.board.persistence.entity.BoardType;
 import com.example.waggle.domain.conversation.application.comment.CommentCommandService;
 import com.example.waggle.domain.conversation.application.comment.CommentQueryService;
 import com.example.waggle.domain.conversation.persistence.entity.Comment;
@@ -20,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -33,7 +33,7 @@ public class CommentApiController {
 
     private final CommentCommandService commentCommandService;
     private final CommentQueryService commentQueryService;
-    private Sort latestSorting = Sort.by("createdDate").descending();
+
 
     @Operation(summary = "특정 게시글(로그, 질답, 사이렌) 댓글 페이징 조회", description = "게시글의 댓글 목록을 페이징 조회합니다.")
     @ApiErrorCodeExample({
@@ -41,8 +41,9 @@ public class CommentApiController {
     })
     @GetMapping("/{boardId}/paged")
     public ApiResponseDto<CommentListDto> getCommentsByPage(@PathVariable("boardId") Long boardId,
+                                                            @RequestParam(name = "boardType") BoardType boardType,
                                                             @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
-        Pageable pageable = PageRequest.of(currentPage, PageUtil.COMMENT_SIZE, latestSorting);
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.COMMENT_SIZE, PageUtil.getCommentSortingMethod(boardType));
         Page<Comment> pagedComments = commentQueryService.getPagedComments(boardId, pageable);
         CommentListDto listDto = CommentConverter.toCommentListDto(pagedComments);
         return ApiResponseDto.onSuccess(listDto);

--- a/src/main/java/com/example/waggle/domain/conversation/presentation/controller/CommentApiController.java
+++ b/src/main/java/com/example/waggle/domain/conversation/presentation/controller/CommentApiController.java
@@ -57,7 +57,7 @@ public class CommentApiController {
     public ApiResponseDto<QuestionCommentListDto> getPagedQuestionCommentsByUserUrl(
             @PathVariable("userUrl") String userUrl,
             @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
-        Pageable pageable = PageRequest.of(currentPage, PageUtil.COMMENT_SIZE, latestSorting);
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.COMMENT_SIZE, PageUtil.LATEST_SORTING);
         Page<QuestionCommentViewDto> pagedQuestionComments = commentQueryService.getPagedQuestionCommentsByUserUrl(
                 userUrl, pageable);
         return ApiResponseDto.onSuccess(CommentConverter.toQuestionCommentListDto(pagedQuestionComments));
@@ -70,7 +70,7 @@ public class CommentApiController {
     @GetMapping("/members/{userUrl}/siren/paged")
     public ApiResponseDto<SirenCommentListDto> getPagedSirenCommentsByUserUrl(@PathVariable("userUrl") String userUrl,
                                                                               @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
-        Pageable pageable = PageRequest.of(currentPage, PageUtil.COMMENT_SIZE, latestSorting);
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.COMMENT_SIZE, PageUtil.LATEST_SORTING);
         Page<SirenCommentViewDto> pagedSirenComments = commentQueryService.getPagedSirenCommentsByUserUrl(
                 userUrl, pageable);
         return ApiResponseDto.onSuccess(CommentConverter.toSirenCommentListDto(pagedSirenComments));

--- a/src/main/java/com/example/waggle/global/util/PageUtil.java
+++ b/src/main/java/com/example/waggle/global/util/PageUtil.java
@@ -14,8 +14,8 @@ public class PageUtil {
     public static int CHAT_MESSAGE_SIZE = 20;
     public static int TEAM_RECOMMEND_SIZE = 3;
 
-    private static Sort LATEST_SORTING = Sort.by("createdDate").descending();
-    private static Sort OLDEST_SORTING = Sort.by("createdDate").ascending();
+    public static Sort LATEST_SORTING = Sort.by("createdDate").descending();
+    public static Sort OLDEST_SORTING = Sort.by("createdDate").ascending();
 
     public static int countNextPage(Page<?> pagedList) {
         if (pagedList.isLast()) {
@@ -26,16 +26,10 @@ public class PageUtil {
 
     public static Sort getCommentSortingMethod(BoardType boardType) {
         switch (boardType) {
-            case STORY -> {
+            case STORY, SCHEDULE -> {
                 return LATEST_SORTING;
             }
-            case SCHEDULE -> {
-                return LATEST_SORTING;
-            }
-            case SIREN -> {
-                return OLDEST_SORTING;
-            }
-            case QUESTION -> {
+            case SIREN, QUESTION -> {
                 return OLDEST_SORTING;
             }
             default -> {

--- a/src/main/java/com/example/waggle/global/util/PageUtil.java
+++ b/src/main/java/com/example/waggle/global/util/PageUtil.java
@@ -1,6 +1,8 @@
 package com.example.waggle.global.util;
 
+import com.example.waggle.domain.board.persistence.entity.BoardType;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 
 public class PageUtil {
     public static int THIS_PAGE_IS_LAST = -1;
@@ -12,11 +14,34 @@ public class PageUtil {
     public static int CHAT_MESSAGE_SIZE = 20;
     public static int TEAM_RECOMMEND_SIZE = 3;
 
+    private static Sort LATEST_SORTING = Sort.by("createdDate").descending();
+    private static Sort OLDEST_SORTING = Sort.by("createdDate").ascending();
+
     public static int countNextPage(Page<?> pagedList) {
         if (pagedList.isLast()) {
             return THIS_PAGE_IS_LAST;
         }
         return pagedList.getNumber() + 1;
+    }
+
+    public static Sort getCommentSortingMethod(BoardType boardType) {
+        switch (boardType) {
+            case STORY -> {
+                return LATEST_SORTING;
+            }
+            case SCHEDULE -> {
+                return LATEST_SORTING;
+            }
+            case SIREN -> {
+                return OLDEST_SORTING;
+            }
+            case QUESTION -> {
+                return OLDEST_SORTING;
+            }
+            default -> {
+                return LATEST_SORTING;
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## 🔎 Description
> refactor comment api
1. 게시글 타입에 맞는 정렬 방법 추가(param 추가)
2. 사이렌, 퀘스쳔 게시글에는 commentCount 데이터 추가


## 🔗 Related Issue
- https://github.com/teamWaggle/Waggle-server/issues/281


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [x] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
