### PR TITLE
[Feat/#284] Implement chat room search API

### DIFF
--- a/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryService.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryService.java
@@ -2,10 +2,9 @@ package com.example.waggle.domain.chat.application.room;
 
 import com.example.waggle.domain.chat.persistence.entity.ChatRoom;
 import com.example.waggle.domain.member.persistence.entity.Member;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
-import java.util.List;
 
 public interface ChatRoomQueryService {
 
@@ -24,5 +23,7 @@ public interface ChatRoomQueryService {
     String getLastSenderProfileImgUrl(Long chatRoomId);
 
     Long countChatRoomsByMemberId(Long memberId);
+
+    Page<ChatRoom> getPagedChatRoomListByKeyword(String keyword, Pageable pageable);
 
 }

--- a/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryServiceImpl.java
@@ -88,6 +88,11 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         return chatRoomRepository.countChatRoomsByMemberId(memberId);
     }
 
+    @Override
+    public Page<ChatRoom> getPagedChatRoomListByKeyword(String keyword, Pageable pageable) {
+        return chatRoomRepository.searchByKeyword(keyword, pageable);
+    }
+
     private Optional<ChatMessage> findLastChatMessageByChatRoomId(Long chatRoomId) {
         PageRequest pageRequest = PageRequest.of(0, 1);
         Page<ChatMessage> pagedChatMessage = chatMessageRepository.findByChatRoomIdSortedBySendTimeDesc(chatRoomId,

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepository.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepository.java
@@ -10,4 +10,6 @@ public interface ChatRoomQueryRepository {
 
     Long countChatRoomsByMemberId(Long memberId);
 
+    Page<ChatRoom> searchByKeyword(String keyword, Pageable pageable);
+
 }

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepositoryImpl.java
@@ -37,10 +37,25 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 
     @Override
     public Long countChatRoomsByMemberId(Long memberId) {
-        return queryFactory
-                .select(chatRoomMember.count())
+        return queryFactory.select(chatRoomMember.count())
                 .from(chatRoomMember)
                 .where(chatRoomMember.member.id.eq(memberId))
                 .fetchFirst();
+    }
+
+    @Override
+    public Page<ChatRoom> searchByKeyword(String keyword, Pageable pageable) {
+        List<ChatRoom> chatRooms = queryFactory.selectFrom(chatRoom)
+                .where(chatRoom.name.contains(keyword).or(chatRoom.description.contains(keyword)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory.select(chatRoom.count())
+                .from(chatRoom)
+                .where(chatRoom.name.contains(keyword).or(chatRoom.description.contains(keyword)))
+                .fetchFirst();
+
+        return new PageImpl<>(chatRooms, pageable, total);
     }
 }

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepositoryImpl.java
@@ -4,12 +4,14 @@ import static com.example.waggle.domain.chat.persistence.entity.QChatRoom.chatRo
 import static com.example.waggle.domain.chat.persistence.entity.QChatRoomMember.chatRoomMember;
 
 import com.example.waggle.domain.chat.persistence.entity.ChatRoom;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -27,12 +29,12 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        long total = queryFactory.select(chatRoomMember.count())
-                .from(chatRoomMember)
-                .where(chatRoomMember.member.id.eq(memberId))
-                .fetchFirst();
+        JPAQuery<Long> countQuery = queryFactory.select(chatRoom.count())
+                .from(chatRoom)
+                .join(chatRoom.chatRoomMembers, chatRoomMember)
+                .where(chatRoomMember.member.id.eq(memberId));
 
-        return new PageImpl<>(chatRooms, pageable, total);
+        return PageableExecutionUtils.getPage(chatRooms, pageable, countQuery::fetchOne);
     }
 
     @Override

--- a/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
+++ b/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
@@ -1,5 +1,7 @@
 package com.example.waggle.domain.chat.presentation.controller;
 
+import static com.example.waggle.global.util.PageUtil.CHAT_ROOM_SIZE;
+
 import com.example.waggle.domain.chat.application.message.ChatMessageQueryService;
 import com.example.waggle.domain.chat.application.room.ChatRoomCommandService;
 import com.example.waggle.domain.chat.application.room.ChatRoomQueryService;
@@ -20,6 +22,7 @@ import com.example.waggle.exception.payload.code.ErrorStatus;
 import com.example.waggle.exception.payload.dto.ApiResponseDto;
 import com.example.waggle.global.annotation.api.ApiErrorCodeExample;
 import com.example.waggle.global.annotation.auth.AuthUser;
+import com.example.waggle.global.util.ObjectUtil;
 import com.example.waggle.global.util.PageUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -186,6 +189,21 @@ public class ChatApiController {
     private ChatMessageDto buildChatMessageDto(ChatMessage chatMessage) {
         Member sender = memberQueryService.getMemberByUserUrl(chatMessage.getSenderUserUrl());
         return ChatConverter.toChatMessageDto(chatMessage, sender);
+    }
+
+    @Operation(summary = "채팅방 검색",
+            description = "주어진 키워드를 기반으로 채팅방을 검색합니다.(name, description) 키워드는 최소 2자 이상이어야 합니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
+    @GetMapping("/rooms/search")
+    public ApiResponseDto<ChatRoomListDto> searchChatRoomList(
+            @RequestParam("keyword") String keyword,
+            @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
+        ObjectUtil.validateKeywordLength(keyword);
+        Pageable pageable = PageRequest.of(currentPage, CHAT_ROOM_SIZE, PageUtil.LATEST_SORTING);
+        return ApiResponseDto.onSuccess(
+                ChatConverter.toChatRoomListDto(chatRoomQueryService.getPagedChatRoomListByKeyword(keyword, pageable)));
     }
 
 }

--- a/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
+++ b/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
@@ -6,6 +6,7 @@ import com.example.waggle.domain.chat.application.room.ChatRoomQueryService;
 import com.example.waggle.domain.chat.persistence.entity.ChatMessage;
 import com.example.waggle.domain.chat.persistence.entity.ChatRoom;
 import com.example.waggle.domain.chat.presentation.converter.ChatConverter;
+import com.example.waggle.domain.chat.presentation.dto.ChatMessageDto;
 import com.example.waggle.domain.chat.presentation.dto.ChatResponse.ActiveChatRoomDto;
 import com.example.waggle.domain.chat.presentation.dto.ChatResponse.ActiveChatRoomListDto;
 import com.example.waggle.domain.chat.presentation.dto.ChatResponse.ChatMessageListDto;
@@ -13,7 +14,6 @@ import com.example.waggle.domain.chat.presentation.dto.ChatResponse.ChatRoomDeta
 import com.example.waggle.domain.chat.presentation.dto.ChatResponse.ChatRoomJoinDto;
 import com.example.waggle.domain.chat.presentation.dto.ChatResponse.ChatRoomListDto;
 import com.example.waggle.domain.chat.presentation.dto.ChatRoomRequest;
-import com.example.waggle.domain.chat.presentation.dto.ChatMessageDto;
 import com.example.waggle.domain.member.application.MemberQueryService;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.exception.payload.code.ErrorStatus;
@@ -32,7 +32,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -55,8 +54,6 @@ public class ChatApiController {
     private final ChatRoomQueryService chatRoomQueryService;
     private final ChatMessageQueryService chatMessageQueryService;
     private final MemberQueryService memberQueryService;
-
-    private static final Sort SORT_BY_CREATED_DATE_DESC = Sort.by("createdDate").descending();
 
     @Operation(summary = "채팅방 생성 🔑", description = "사용자가 새로운 채팅방을 생성합니다. 생성 성공 시 채팅방의 고유 ID를 반환합니다.")
     @ApiErrorCodeExample({
@@ -127,7 +124,7 @@ public class ChatApiController {
     @GetMapping("/rooms/paged")
     public ApiResponseDto<ChatRoomListDto> getPagedChatRooms(
             @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
-        Pageable pageable = PageRequest.of(currentPage, PageUtil.CHAT_ROOM_SIZE, SORT_BY_CREATED_DATE_DESC);
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.CHAT_ROOM_SIZE, PageUtil.LATEST_SORTING);
         return ApiResponseDto.onSuccess(
                 ChatConverter.toChatRoomListDto(chatRoomQueryService.getPagedChatRooms(pageable)));
     }


### PR DESCRIPTION
## 🔎 Description
> 아직 기능이 확실하게 명세되지 않아, 우선 name과 description 기준으로 검색 API를 구현했습니다.
- 기존에 static final 변수로 선언되어 있던 정렬 변수를 `PageUtil.LATEST_SORTING`으로 교체했습니다.

## 🔗 Related Issue
- [https://github.com/teamWaggle/Waggle-server/issues/284](https://github.com/teamWaggle/Waggle-server/issues/284)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [x] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
