### PR TITLE
[Feat/#262] Implement Viewing Only Messages After Joining the Chat

### DIFF
--- a/src/main/java/com/example/waggle/domain/chat/application/message/ChatMessageQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/message/ChatMessageQueryServiceImpl.java
@@ -3,9 +3,11 @@ package com.example.waggle.domain.chat.application.message;
 import com.example.waggle.domain.chat.persistence.dao.ChatMessageRepository;
 import com.example.waggle.domain.chat.persistence.dao.ChatRoomMemberRepository;
 import com.example.waggle.domain.chat.persistence.entity.ChatMessage;
+import com.example.waggle.domain.chat.persistence.entity.ChatRoomMember;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.exception.object.handler.ChatRoomHandler;
 import com.example.waggle.exception.payload.code.ErrorStatus;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -24,9 +26,13 @@ public class ChatMessageQueryServiceImpl implements ChatMessageQueryService {
 
     @Override
     public Page<ChatMessage> getPagedChatMessages(Member member, Long chatRoomId, Pageable pageable) {
-        if (chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, member.getId()).isEmpty()) {
-            throw new ChatRoomHandler(ErrorStatus.CHAT_ROOM_MEMBER_NOT_FOUND);
-        }
-        return chatMessageRepository.findByChatRoomIdSortedBySendTimeDesc(chatRoomId, pageable);
+        ChatRoomMember chatRoomMember = chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, member.getId())
+                .orElseThrow(() -> new ChatRoomHandler(ErrorStatus.CHAT_ROOM_MEMBER_NOT_FOUND));
+
+        long memberEnterTime = chatRoomMember.getCreatedDate().atZone(ZoneId.of("Asia/Seoul")).toInstant()
+                .toEpochMilli();
+
+        return chatMessageRepository.findMessagesByChatRoomIdAfterMemberEnterTime(chatRoomId, memberEnterTime,
+                pageable);
     }
 }

--- a/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryServiceImpl.java
@@ -67,7 +67,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
     @Override
     public String getLastMessageContent(Long chatRoomId) {
-        Page<ChatMessage> pagedChatMessage = chatMessageRepository.findByChatRoomIdSortedBySendTimeDesc(
+        Page<ChatMessage> pagedChatMessage = chatMessageRepository.findRecentMessagesByChatRoomId(
                 chatRoomId, PageRequest.of(0, 1));
         if (!pagedChatMessage.hasContent()) {
             return "최근 메시지가 없습니다.";
@@ -90,7 +90,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
     private Optional<ChatMessage> findLastChatMessageByChatRoomId(Long chatRoomId) {
         PageRequest pageRequest = PageRequest.of(0, 1);
-        Page<ChatMessage> pagedChatMessage = chatMessageRepository.findByChatRoomIdSortedBySendTimeDesc(chatRoomId,
+        Page<ChatMessage> pagedChatMessage = chatMessageRepository.findRecentMessagesByChatRoomId(chatRoomId,
                 pageRequest);
         return pagedChatMessage.getContent().stream().findFirst();
     }

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatMessageRepository.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatMessageRepository.java
@@ -12,6 +12,10 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
     long countByChatRoomIdAndSendTimeAfter(Long chatRoomId, long lastAccessTime);
 
     @Query(value = "{'chatRoomId': ?0}", sort = "{'sendTime': -1}")
-    Page<ChatMessage> findByChatRoomIdSortedBySendTimeDesc(Long chatRoomId, Pageable pageable);
+    Page<ChatMessage> findRecentMessagesByChatRoomId(Long chatRoomId, Pageable pageable);
+
+    @Query(value = "{'chatRoomId': ?0, 'sendTime': {$gt: ?1}}", sort = "{'sendTime': -1}")
+    Page<ChatMessage> findMessagesByChatRoomIdAfterMemberEnterTime(Long chatRoomId, Long memberEnterTime,
+                                                                   Pageable pageable);
 
 }


### PR DESCRIPTION
## 🔎 Description
> Implement Viewing Only Messages After Joining the Chat 
- 사용자가 채팅방에 입장한 시간 이후의 메시지만 조회할 수 있도록 로직을 개선했습니다.
- 사용자가 메시지를 주고 받을 때마다 lastAccessTime을 갱신하도록 로직을 개선했습니다.

## 🔗 Related Issue
- [https://github.com/teamWaggle/Waggle-server/issues/262](https://github.com/teamWaggle/Waggle-server/issues/262)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
