### PR TITLE
[Feat/#288] Add scheduleId field to overlapping schedules API response

### DIFF
--- a/src/main/java/com/example/waggle/domain/schedule/presentation/converter/ScheduleConverter.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/converter/ScheduleConverter.java
@@ -63,6 +63,7 @@ public class ScheduleConverter {
                 .scheduleTitle(schedule.getTitle())
                 .teamName(schedule.getTeam().getName())
                 .teamColor(schedule.getTeam().getTeamColor())
+                .scheduleId(schedule.getId())
                 .build();
     }
 

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/dto/schedule/ScheduleResponse.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/dto/schedule/ScheduleResponse.java
@@ -23,6 +23,7 @@ public class ScheduleResponse {
         private String teamName;
         private TeamColor teamColor;
         private String scheduleTitle;
+        private Long scheduleId;
     }
 
 


### PR DESCRIPTION
## 🔎 Description
> 겹치는 일정 조회 API에 scheduleId 필드를 추가했습니다.


## 🔗 Related Issue
- [https://github.com/teamWaggle/Waggle-server/issues/288](https://github.com/teamWaggle/Waggle-server/issues/288)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
