### PR TITLE
[Refactor/#297] move comment count data to comment list view api

### DIFF
--- a/src/main/java/com/example/waggle/domain/board/presentation/converter/QuestionConverter.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/converter/QuestionConverter.java
@@ -49,7 +49,6 @@ public class QuestionConverter {
                 .mediaList(MediaUtil.getBoardMedias(question))
                 .member(MemberConverter.toMemberSummaryDto(question.getMember()))
                 .viewCount(question.getViewCount())
-                .commentCount(question.getComments().size())
                 .build();
     }
 

--- a/src/main/java/com/example/waggle/domain/board/presentation/converter/SirenConverter.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/converter/SirenConverter.java
@@ -53,7 +53,6 @@ public class SirenConverter {
                 .status(siren.getStatus())
                 .member(MemberConverter.toMemberSummaryDto(siren.getMember()))
                 .viewCount(siren.getViewCount())
-                .commentCount(siren.getComments().size())
                 .build();
     }
 

--- a/src/main/java/com/example/waggle/domain/board/presentation/dto/question/QuestionResponse.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/dto/question/QuestionResponse.java
@@ -54,7 +54,6 @@ public class QuestionResponse {
         private MemberSummaryDto member;
         private int recommendCount;
         private long viewCount;
-        private int commentCount;
     }
 
     @Data

--- a/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenResponse.java
+++ b/src/main/java/com/example/waggle/domain/board/presentation/dto/siren/SirenResponse.java
@@ -54,7 +54,6 @@ public class SirenResponse {
         private ResolutionStatus status;
         private int recommendCount;
         private long viewCount;
-        private int commentCount;
     }
 
     @Data

--- a/src/main/java/com/example/waggle/domain/conversation/presentation/converter/CommentConverter.java
+++ b/src/main/java/com/example/waggle/domain/conversation/presentation/converter/CommentConverter.java
@@ -1,19 +1,13 @@
 package com.example.waggle.domain.conversation.presentation.converter;
 
 import com.example.waggle.domain.conversation.persistence.entity.Comment;
+import com.example.waggle.domain.conversation.presentation.dto.comment.CommentResponse.*;
+import com.example.waggle.domain.member.presentation.converter.MemberConverter;
 import com.example.waggle.global.util.PageUtil;
-import com.example.waggle.domain.conversation.presentation.dto.comment.CommentResponse.CommentListDto;
-import com.example.waggle.domain.conversation.presentation.dto.comment.CommentResponse.CommentViewDto;
-import com.example.waggle.domain.conversation.presentation.dto.comment.CommentResponse.QuestionCommentListDto;
-import com.example.waggle.domain.conversation.presentation.dto.comment.CommentResponse.QuestionCommentViewDto;
-import com.example.waggle.domain.conversation.presentation.dto.comment.CommentResponse.SirenCommentListDto;
-import com.example.waggle.domain.conversation.presentation.dto.comment.CommentResponse.SirenCommentViewDto;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
-import com.example.waggle.domain.member.presentation.converter.MemberConverter;
-import org.springframework.data.domain.Page;
 
 public class CommentConverter {
 
@@ -32,6 +26,7 @@ public class CommentConverter {
         return CommentListDto.builder()
                 .commentList(collect)
                 .nextPageParam(PageUtil.countNextPage(pagedComment))
+                .totalCount(pagedComment.getTotalElements())
                 .build();
     }
 

--- a/src/main/java/com/example/waggle/domain/conversation/presentation/dto/comment/CommentResponse.java
+++ b/src/main/java/com/example/waggle/domain/conversation/presentation/dto/comment/CommentResponse.java
@@ -4,14 +4,13 @@ import com.example.waggle.domain.board.persistence.entity.ResolutionStatus;
 import com.example.waggle.domain.board.persistence.entity.SirenCategory;
 import com.example.waggle.domain.member.presentation.dto.MemberResponse.MemberSummaryDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class CommentResponse {
 
@@ -35,6 +34,7 @@ public class CommentResponse {
     public static class CommentListDto {
         private List<CommentViewDto> commentList;
         private int nextPageParam;
+        private long totalCount;
     }
 
     @Data


### PR DESCRIPTION
## 🔎 Description
> question, siren 에 존재하던 comment count 데이터를 comment list dto에 넣어줌


## 🔗 Related Issue
- https://github.com/teamWaggle/Waggle-server/issues/297


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [x] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
