### PR TITLE
[Feat/#300] Enhance Member Deletion Logic with ChatRoom

### DIFF
--- a/src/main/java/com/example/waggle/domain/chat/application/ChatMessageCommandService.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/ChatMessageCommandService.java
@@ -1,4 +1,4 @@
-package com.example.waggle.domain.chat.application.message;
+package com.example.waggle.domain.chat.application;
 
 import com.example.waggle.domain.chat.presentation.dto.ChatMessageDto;
 

--- a/src/main/java/com/example/waggle/domain/chat/application/ChatMessageCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/ChatMessageCommandServiceImpl.java
@@ -1,4 +1,4 @@
-package com.example.waggle.domain.chat.application.message;
+package com.example.waggle.domain.chat.application;
 
 import com.example.waggle.domain.chat.persistence.entity.ChatMessage;
 import com.example.waggle.domain.chat.persistence.dao.ChatMessageRepository;

--- a/src/main/java/com/example/waggle/domain/chat/application/ChatMessageQueryService.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/ChatMessageQueryService.java
@@ -1,4 +1,4 @@
-package com.example.waggle.domain.chat.application.message;
+package com.example.waggle.domain.chat.application;
 
 import com.example.waggle.domain.chat.persistence.entity.ChatMessage;
 import com.example.waggle.domain.member.persistence.entity.Member;

--- a/src/main/java/com/example/waggle/domain/chat/application/ChatMessageQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/ChatMessageQueryServiceImpl.java
@@ -1,4 +1,4 @@
-package com.example.waggle.domain.chat.application.message;
+package com.example.waggle.domain.chat.application;
 
 import com.example.waggle.domain.chat.persistence.dao.ChatMessageRepository;
 import com.example.waggle.domain.chat.persistence.dao.ChatRoomMemberRepository;

--- a/src/main/java/com/example/waggle/domain/chat/application/ChatRoomCommandService.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/ChatRoomCommandService.java
@@ -1,4 +1,4 @@
-package com.example.waggle.domain.chat.application.room;
+package com.example.waggle.domain.chat.application;
 
 import com.example.waggle.domain.chat.presentation.dto.ChatRoomRequest;
 import com.example.waggle.domain.member.persistence.entity.Member;

--- a/src/main/java/com/example/waggle/domain/chat/application/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/ChatRoomCommandServiceImpl.java
@@ -1,4 +1,4 @@
-package com.example.waggle.domain.chat.application.room;
+package com.example.waggle.domain.chat.application;
 
 import com.example.waggle.domain.chat.persistence.dao.ChatRoomMemberRepository;
 import com.example.waggle.domain.chat.persistence.dao.ChatRoomRepository;

--- a/src/main/java/com/example/waggle/domain/chat/application/ChatRoomQueryService.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/ChatRoomQueryService.java
@@ -1,4 +1,4 @@
-package com.example.waggle.domain.chat.application.room;
+package com.example.waggle.domain.chat.application;
 
 import com.example.waggle.domain.chat.persistence.entity.ChatRoom;
 import com.example.waggle.domain.member.persistence.entity.Member;

--- a/src/main/java/com/example/waggle/domain/chat/application/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/ChatRoomQueryServiceImpl.java
@@ -1,4 +1,4 @@
-package com.example.waggle.domain.chat.application.room;
+package com.example.waggle.domain.chat.application;
 
 import com.example.waggle.domain.chat.persistence.dao.ChatMessageRepository;
 import com.example.waggle.domain.chat.persistence.dao.ChatRoomMemberRepository;

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatMessageRepository.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatMessageRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
 
     @Query(value = "{'chatRoomId': ?0, 'sendTime': {$gt: ?1}}", count = true)
@@ -17,5 +19,7 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
     @Query(value = "{'chatRoomId': ?0, 'sendTime': {$gt: ?1}}", sort = "{'sendTime': -1}")
     Page<ChatMessage> findMessagesByChatRoomIdAfterMemberEnterTime(Long chatRoomId, Long memberEnterTime,
                                                                    Pageable pageable);
+
+    void deleteAllByChatRoomId(Long chatRoomId);
 
 }

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatRoomMemberRepository.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatRoomMemberRepository.java
@@ -1,6 +1,7 @@
 package com.example.waggle.domain.chat.persistence.dao;
 
 import com.example.waggle.domain.chat.persistence.entity.ChatRoomMember;
+import com.example.waggle.domain.member.persistence.entity.Member;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,5 +11,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     Optional<ChatRoomMember> findByChatRoomIdAndMemberId(Long chatRoomId, Long memberId);
 
     List<ChatRoomMember> findAllByMemberId(Long memberId);
+
+    void deleteAllByMember(Member member);
 
 }

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatRoomMemberRepository.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatRoomMemberRepository.java
@@ -1,5 +1,6 @@
 package com.example.waggle.domain.chat.persistence.dao;
 
+import com.example.waggle.domain.chat.persistence.entity.ChatRoom;
 import com.example.waggle.domain.chat.persistence.entity.ChatRoomMember;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import java.util.List;
@@ -13,5 +14,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     List<ChatRoomMember> findAllByMemberId(Long memberId);
 
     void deleteAllByMember(Member member);
+
+    void deleteAllByChatRoom(ChatRoom chatRoom);
 
 }

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatRoomRepository.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatRoomRepository.java
@@ -2,7 +2,11 @@ package com.example.waggle.domain.chat.persistence.dao;
 
 import com.example.waggle.domain.chat.persistence.dao.querydsl.ChatRoomQueryRepository;
 import com.example.waggle.domain.chat.persistence.entity.ChatRoom;
+import com.example.waggle.domain.member.persistence.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomQueryRepository {
+
+    void deleteAllByOwner(Member owner);
+
 }

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatRoomRepository.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/ChatRoomRepository.java
@@ -3,10 +3,13 @@ package com.example.waggle.domain.chat.persistence.dao;
 import com.example.waggle.domain.chat.persistence.dao.querydsl.ChatRoomQueryRepository;
 import com.example.waggle.domain.chat.persistence.entity.ChatRoom;
 import com.example.waggle.domain.member.persistence.entity.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomQueryRepository {
 
     void deleteAllByOwner(Member owner);
+
+    List<ChatRoom> findByOwner(Member owner);
 
 }

--- a/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
+++ b/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
@@ -2,9 +2,9 @@ package com.example.waggle.domain.chat.presentation.controller;
 
 import static com.example.waggle.global.util.PageUtil.CHAT_ROOM_SIZE;
 
-import com.example.waggle.domain.chat.application.message.ChatMessageQueryService;
-import com.example.waggle.domain.chat.application.room.ChatRoomCommandService;
-import com.example.waggle.domain.chat.application.room.ChatRoomQueryService;
+import com.example.waggle.domain.chat.application.ChatMessageQueryService;
+import com.example.waggle.domain.chat.application.ChatRoomCommandService;
+import com.example.waggle.domain.chat.application.ChatRoomQueryService;
 import com.example.waggle.domain.chat.persistence.entity.ChatMessage;
 import com.example.waggle.domain.chat.persistence.entity.ChatRoom;
 import com.example.waggle.domain.chat.presentation.converter.ChatConverter;

--- a/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
+++ b/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -187,7 +188,7 @@ public class ChatApiController {
     }
 
     private ChatMessageDto buildChatMessageDto(ChatMessage chatMessage) {
-        Member sender = memberQueryService.findOptionalMemberByUserUrl(chatMessage.getSenderUserUrl()).orElse(null);
+        Optional<Member> sender = memberQueryService.findOptionalMemberByUserUrl(chatMessage.getSenderUserUrl());
         return ChatConverter.toChatMessageDto(chatMessage, sender);
     }
 

--- a/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
+++ b/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
@@ -187,7 +187,7 @@ public class ChatApiController {
     }
 
     private ChatMessageDto buildChatMessageDto(ChatMessage chatMessage) {
-        Member sender = memberQueryService.getMemberByUserUrl(chatMessage.getSenderUserUrl());
+        Member sender = memberQueryService.findOptionalMemberByUserUrl(chatMessage.getSenderUserUrl()).orElse(null);
         return ChatConverter.toChatMessageDto(chatMessage, sender);
     }
 

--- a/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatMessageController.java
+++ b/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatMessageController.java
@@ -1,6 +1,6 @@
 package com.example.waggle.domain.chat.presentation.controller;
 
-import com.example.waggle.domain.chat.application.message.ChatMessageCommandService;
+import com.example.waggle.domain.chat.application.ChatMessageCommandService;
 import com.example.waggle.domain.chat.presentation.dto.ChatMessageDto;
 import com.example.waggle.domain.member.application.MemberQueryService;
 import com.example.waggle.domain.member.persistence.entity.Member;

--- a/src/main/java/com/example/waggle/domain/chat/presentation/converter/ChatConverter.java
+++ b/src/main/java/com/example/waggle/domain/chat/presentation/converter/ChatConverter.java
@@ -18,6 +18,7 @@ import com.example.waggle.global.util.MediaUtil;
 import com.example.waggle.global.util.PageUtil;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 
@@ -71,17 +72,17 @@ public class ChatConverter {
                 .build();
     }
 
-    public static ChatMessageDto toChatMessageDto(ChatMessage chatMessage, Member sender) {
-        String nickname = sender != null ? sender.getNickname() : "알 수 없음";
-        String profileImg =
-                sender != null ? MediaUtil.getProfileImg(sender) : MediaUtil.getDefaultMemberProfileImgUrl();
+    public static ChatMessageDto toChatMessageDto(ChatMessage chatMessage, Optional<Member> sender) {
+        String nickname = sender.map(Member::getNickname).orElse("알 수 없음");
+        String profileImg = sender.map(MediaUtil::getProfileImg).orElse(MediaUtil.getDefaultMemberProfileImgUrl());
+        String senderUserUrl = sender.map(Member::getUserUrl).orElse(null);
 
         return ChatMessageDto.builder()
                 .id(chatMessage.getId())
                 .chatRoomId(chatMessage.getChatRoomId())
                 .chatMessageType(chatMessage.getChatMessageType())
                 .content(chatMessage.getContent())
-                .senderUserUrl(sender.getUserUrl())
+                .senderUserUrl(senderUserUrl)
                 .senderNickname(nickname)
                 .senderProfileImgUrl(profileImg)
                 .sendTime(chatMessage.getSendTime())

--- a/src/main/java/com/example/waggle/domain/chat/presentation/converter/ChatConverter.java
+++ b/src/main/java/com/example/waggle/domain/chat/presentation/converter/ChatConverter.java
@@ -72,14 +72,18 @@ public class ChatConverter {
     }
 
     public static ChatMessageDto toChatMessageDto(ChatMessage chatMessage, Member sender) {
+        String nickname = sender != null ? sender.getNickname() : "알 수 없음";
+        String profileImg =
+                sender != null ? MediaUtil.getProfileImg(sender) : MediaUtil.getDefaultMemberProfileImgUrl();
+
         return ChatMessageDto.builder()
                 .id(chatMessage.getId())
                 .chatRoomId(chatMessage.getChatRoomId())
                 .chatMessageType(chatMessage.getChatMessageType())
                 .content(chatMessage.getContent())
                 .senderUserUrl(sender.getUserUrl())
-                .senderNickname(sender.getNickname())
-                .senderProfileImgUrl(MediaUtil.getProfileImg(sender))
+                .senderNickname(nickname)
+                .senderProfileImgUrl(profileImg)
                 .sendTime(chatMessage.getSendTime())
                 .build();
     }

--- a/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
@@ -178,6 +178,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         commentRepository.deleteAllByMemberId(memberId);
         boardRepository.deleteBoardsWithRelationsByMemberId(memberId);
         teamRepository.deleteTeamWithRelationsByMemberId(memberId);
+        chatRoomMemberRepository.deleteAllByMember(member);
         chatRoomRepository.deleteAllByOwner(member);
         memberRepository.deleteMemberWithRelations(memberId);
     }

--- a/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
@@ -176,6 +176,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         commentRepository.deleteAllByMemberId(memberId);
         boardRepository.deleteBoardsWithRelationsByMemberId(memberId);
         teamRepository.deleteTeamWithRelationsByMemberId(memberId);
+        chatRoomRepository.deleteAllByOwner(member);
         memberRepository.deleteMemberWithRelations(memberId);
     }
 

--- a/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
@@ -4,8 +4,10 @@ import static com.example.waggle.security.oauth.factory.OAuth2UserInfoFactory.Au
 
 import com.example.waggle.domain.board.persistence.dao.board.jpa.BoardRepository;
 import com.example.waggle.domain.board.persistence.entity.Board;
+import com.example.waggle.domain.chat.persistence.dao.ChatMessageRepository;
 import com.example.waggle.domain.chat.persistence.dao.ChatRoomMemberRepository;
 import com.example.waggle.domain.chat.persistence.dao.ChatRoomRepository;
+import com.example.waggle.domain.chat.persistence.entity.ChatRoom;
 import com.example.waggle.domain.conversation.persistence.dao.comment.jpa.CommentRepository;
 import com.example.waggle.domain.conversation.persistence.dao.reply.ReplyRepository;
 import com.example.waggle.domain.conversation.persistence.entity.Comment;
@@ -72,6 +74,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final MemberRepository memberRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     private final MemberQueryService memberQueryService;
     private final RedisService redisService;
@@ -151,6 +154,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         deleteAllDataLinkedToMember(member);
         deleteMemberContent(member);
         deleteMemberTeams(member);
+        deleteChatRoomsAndMessages(member);
 
         memberRepository.delete(member);
     }
@@ -239,6 +243,14 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         List<TeamMember> teamMemberships = teamMemberRepository.findAllByMember(member);
         teamMemberRepository.deleteAll(teamMemberships);
+    }
+
+    private void deleteChatRoomsAndMessages(Member member) {
+        List<ChatRoom> chatRooms = chatRoomRepository.findByOwner(member);
+        for (ChatRoom chatRoom : chatRooms) {
+            chatMessageRepository.deleteAllByChatRoomId(chatRoom.getId());
+            chatRoomRepository.delete(chatRoom);
+        }
     }
 
     @Override

--- a/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
@@ -4,6 +4,7 @@ import static com.example.waggle.security.oauth.factory.OAuth2UserInfoFactory.Au
 
 import com.example.waggle.domain.board.persistence.dao.board.jpa.BoardRepository;
 import com.example.waggle.domain.board.persistence.entity.Board;
+import com.example.waggle.domain.chat.persistence.dao.ChatRoomMemberRepository;
 import com.example.waggle.domain.chat.persistence.dao.ChatRoomRepository;
 import com.example.waggle.domain.conversation.persistence.dao.comment.jpa.CommentRepository;
 import com.example.waggle.domain.conversation.persistence.dao.reply.ReplyRepository;
@@ -70,6 +71,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
 
     private final MemberQueryService memberQueryService;
     private final RedisService redisService;
@@ -186,6 +188,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         followRepository.deleteAllByFromMember(member);
         participationRepository.deleteAllByMember(member);
         recommendRepository.deleteAllByMember(member);
+        chatRoomMemberRepository.deleteAllByMember(member);
         chatRoomRepository.deleteAllByOwner(member);
     }
 

--- a/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
@@ -1,7 +1,10 @@
 package com.example.waggle.domain.member.application;
 
+import static com.example.waggle.security.oauth.factory.OAuth2UserInfoFactory.AuthProvider.WAGGLE;
+
 import com.example.waggle.domain.board.persistence.dao.board.jpa.BoardRepository;
 import com.example.waggle.domain.board.persistence.entity.Board;
+import com.example.waggle.domain.chat.persistence.dao.ChatRoomRepository;
 import com.example.waggle.domain.conversation.persistence.dao.comment.jpa.CommentRepository;
 import com.example.waggle.domain.conversation.persistence.dao.reply.ReplyRepository;
 import com.example.waggle.domain.conversation.persistence.entity.Comment;
@@ -18,7 +21,11 @@ import com.example.waggle.domain.member.presentation.dto.MemberRequest.MemberUpd
 import com.example.waggle.domain.member.presentation.dto.VerifyMailRequest.EmailVerificationDto;
 import com.example.waggle.domain.pet.persistence.dao.PetRepository;
 import com.example.waggle.domain.recommend.persistence.dao.RecommendRepository;
-import com.example.waggle.domain.schedule.persistence.dao.jpa.*;
+import com.example.waggle.domain.schedule.persistence.dao.jpa.MemberScheduleRepository;
+import com.example.waggle.domain.schedule.persistence.dao.jpa.ParticipationRepository;
+import com.example.waggle.domain.schedule.persistence.dao.jpa.ScheduleRepository;
+import com.example.waggle.domain.schedule.persistence.dao.jpa.TeamMemberRepository;
+import com.example.waggle.domain.schedule.persistence.dao.jpa.TeamRepository;
 import com.example.waggle.domain.schedule.persistence.entity.Schedule;
 import com.example.waggle.domain.schedule.persistence.entity.Team;
 import com.example.waggle.domain.schedule.persistence.entity.TeamMember;
@@ -29,21 +36,18 @@ import com.example.waggle.global.service.redis.RedisService;
 import com.example.waggle.global.util.MediaUtil;
 import com.example.waggle.global.util.NameUtil;
 import com.example.waggle.global.util.NameUtil.NameType;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import static com.example.waggle.security.oauth.factory.OAuth2UserInfoFactory.AuthProvider.WAGGLE;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -65,6 +69,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final TeamMemberRepository teamMemberRepository;
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     private final MemberQueryService memberQueryService;
     private final RedisService redisService;
@@ -180,6 +185,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         followRepository.deleteAllByFromMember(member);
         participationRepository.deleteAllByMember(member);
         recommendRepository.deleteAllByMember(member);
+        chatRoomRepository.deleteAllByOwner(member);
     }
 
     private void deleteMemberContent(Member member) {

--- a/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
@@ -182,8 +182,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         commentRepository.deleteAllByMemberId(memberId);
         boardRepository.deleteBoardsWithRelationsByMemberId(memberId);
         teamRepository.deleteTeamWithRelationsByMemberId(memberId);
+        deleteChatRoomsAndMessages(member);
         chatRoomMemberRepository.deleteAllByMember(member);
-        chatRoomRepository.deleteAllByOwner(member);
         memberRepository.deleteMemberWithRelations(memberId);
     }
 

--- a/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
@@ -183,7 +183,6 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         boardRepository.deleteBoardsWithRelationsByMemberId(memberId);
         teamRepository.deleteTeamWithRelationsByMemberId(memberId);
         deleteChatRoomsAndMessages(member);
-        chatRoomMemberRepository.deleteAllByMember(member);
         memberRepository.deleteMemberWithRelations(memberId);
     }
 
@@ -193,8 +192,6 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         followRepository.deleteAllByFromMember(member);
         participationRepository.deleteAllByMember(member);
         recommendRepository.deleteAllByMember(member);
-        chatRoomMemberRepository.deleteAllByMember(member);
-        chatRoomRepository.deleteAllByOwner(member);
     }
 
     private void deleteMemberContent(Member member) {
@@ -252,6 +249,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             chatRoomMemberRepository.deleteAllByChatRoom(chatRoom);
             chatRoomRepository.delete(chatRoom);
         }
+        chatRoomMemberRepository.deleteAllByMember(member);
     }
 
     @Override

--- a/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/member/application/MemberCommandServiceImpl.java
@@ -249,6 +249,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         List<ChatRoom> chatRooms = chatRoomRepository.findByOwner(member);
         for (ChatRoom chatRoom : chatRooms) {
             chatMessageRepository.deleteAllByChatRoomId(chatRoom.getId());
+            chatRoomMemberRepository.deleteAllByChatRoom(chatRoom);
             chatRoomRepository.delete(chatRoom);
         }
     }

--- a/src/main/java/com/example/waggle/domain/member/application/MemberQueryService.java
+++ b/src/main/java/com/example/waggle/domain/member/application/MemberQueryService.java
@@ -4,6 +4,7 @@ import com.example.waggle.domain.member.persistence.entity.Member;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface MemberQueryService {
 
@@ -14,6 +15,8 @@ public interface MemberQueryService {
     Member getMemberById(Long memberId);
 
     Member getMemberByUserUrl(String userUrl);
+
+    Optional<Member> findOptionalMemberByUserUrl(String userUrl);
 
     List<Member> getMembersByNameAndBirthday(String name, LocalDate birthday);
 

--- a/src/main/java/com/example/waggle/domain/member/application/MemberQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/member/application/MemberQueryServiceImpl.java
@@ -5,12 +5,12 @@ import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.exception.object.handler.MemberHandler;
 import com.example.waggle.exception.payload.code.ErrorStatus;
 import com.example.waggle.global.util.SecurityUtil;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -40,6 +40,11 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     public Member getMemberByUserUrl(String userUrl) {
         return memberRepository.findByUserUrl(userUrl)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    @Override
+    public Optional<Member> findOptionalMemberByUserUrl(String userUrl) {
+        return memberRepository.findByUserUrl(userUrl);
     }
 
     @Override

--- a/src/main/java/com/example/waggle/domain/member/presentation/controller/MemberApiController.java
+++ b/src/main/java/com/example/waggle/domain/member/presentation/controller/MemberApiController.java
@@ -1,6 +1,6 @@
 package com.example.waggle.domain.member.presentation.controller;
 
-import com.example.waggle.domain.chat.application.room.ChatRoomQueryService;
+import com.example.waggle.domain.chat.application.ChatRoomQueryService;
 import com.example.waggle.domain.follow.application.FollowQueryService;
 import com.example.waggle.domain.member.application.MemberCommandService;
 import com.example.waggle.domain.member.application.MemberQueryService;
@@ -141,7 +141,8 @@ public class MemberApiController {
             ErrorStatus.MEMBER_NOT_FOUND
     })
     @PostMapping("/email/verify/password")
-    public ApiResponseDto<Long> verifyMailForPasswordChanging(@RequestBody EmailVerificationDto emailVerificationRequest) {
+    public ApiResponseDto<Long> verifyMailForPasswordChanging(
+            @RequestBody EmailVerificationDto emailVerificationRequest) {
         Long memberId = memberCommandService.verifyEmailForPasswordChange(emailVerificationRequest);
         return ApiResponseDto.onSuccess(memberId);
     }

--- a/src/main/java/com/example/waggle/global/config/websocket/StompHandler.java
+++ b/src/main/java/com/example/waggle/global/config/websocket/StompHandler.java
@@ -4,7 +4,7 @@ import static org.springframework.messaging.simp.stomp.StompCommand.CONNECT;
 import static org.springframework.messaging.simp.stomp.StompCommand.SEND;
 import static org.springframework.messaging.simp.stomp.StompCommand.SUBSCRIBE;
 
-import com.example.waggle.domain.chat.application.room.ChatRoomCommandService;
+import com.example.waggle.domain.chat.application.ChatRoomCommandService;
 import com.example.waggle.domain.member.application.MemberQueryService;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.exception.object.handler.MemberHandler;

--- a/src/main/java/com/example/waggle/global/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/example/waggle/global/config/websocket/WebSocketConfig.java
@@ -20,7 +20,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/chat")
                 .setAllowedOriginPatterns("*");
-//                .withSockJS();
     }
 
     @Override

--- a/src/main/resources/templates/chat/roomdetail.html
+++ b/src/main/resources/templates/chat/roomdetail.html
@@ -44,13 +44,8 @@
 <!-- JavaScript -->
 <script src="/webjars/vue/2.5.16/dist/vue.min.js"></script>
 <script src="/webjars/axios/0.17.1/dist/axios.min.js"></script>
-<script src="/webjars/sockjs-client/1.1.2/sockjs.min.js"></script>
 <script src="/webjars/stomp-websocket/2.3.3-1/stomp.min.js"></script>
 <script>
-    // websocket & stomp initialize
-    var sock = new SockJS("/ws/chat");
-    var ws = Stomp.over(sock);
-    var reconnect = 0;
     // vue.js
     var vm = new Vue({
         el: '#app',
@@ -62,6 +57,8 @@
             content: '',
             messages: [],
             hasJoined: false,
+            ws: null,
+            reconnect: 0
         },
         created() {
             this.chatRoomId = localStorage.getItem('wschat.chatRoomId');
@@ -140,7 +137,7 @@
                 })
             },
             sendSystemMessage: function (type) {
-                ws.send("/publish/message", {
+                this.ws.send("/publish/message", {
                     'Authorization': 'Bearer ' + this.accessToken
                 }, JSON.stringify({
                     chatMessageType: type,
@@ -157,7 +154,7 @@
             },
             connect: function () {
                 console.log('Attempting to connect...');
-                this.ws = Stomp.over(new SockJS("/ws/chat"));
+                this.ws = Stomp.over(new WebSocket("ws://" + window.location.host + "/ws/chat"));
                 this.ws.connect({
                     'Authorization': 'Bearer ' + this.accessToken
                 }, (frame) => {
@@ -180,7 +177,6 @@
             }
         }
     });
-
 
     function leaveChatRoom() {
         axios.delete(`/api/chat/rooms/${vm.chatRoomId}/leave`, {


### PR DESCRIPTION
## 🔎 Description
> Implement chat room deletion logic
- 회원 삭제 메서드에 채팅방 관련 삭제 로직 추가
- 탈퇴한 회원 "알 수 없음" 처리

## 🔗 Related Issue
- [https://github.com/teamWaggle/Waggle-server/issues/300](https://github.com/teamWaggle/Waggle-server/issues/300)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
