### PR TITLE
[Feat/#302] Integrate Chat Room APIs and Exclude Member's Chat Rooms

### DIFF
--- a/src/main/java/com/example/waggle/domain/board/persistence/entity/Question.java
+++ b/src/main/java/com/example/waggle/domain/board/persistence/entity/Question.java
@@ -31,8 +31,4 @@ public class Question extends Board {
         this.status = status;
     }
 
-    public void increaseViewCount() {
-        viewCount++;
-    }
-
 }

--- a/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryService.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryService.java
@@ -26,4 +26,6 @@ public interface ChatRoomQueryService {
 
     Page<ChatRoom> getPagedChatRoomListByKeyword(String keyword, Pageable pageable);
 
+    Page<ChatRoom> getPagedChatRoomListByKeywordExcludingMember(Member member, String keyword, Pageable pageable);
+
 }

--- a/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryServiceImpl.java
@@ -93,6 +93,12 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         return chatRoomRepository.findChatRoomsByKeyword(keyword, pageable);
     }
 
+    @Override
+    public Page<ChatRoom> getPagedChatRoomListByKeywordExcludingMember(Member member, String keyword,
+                                                                       Pageable pageable) {
+        return chatRoomRepository.findChatRoomsByKeywordExcludingMember(member, keyword, pageable);
+    }
+
     private Optional<ChatMessage> findLastChatMessageByChatRoomId(Long chatRoomId) {
         PageRequest pageRequest = PageRequest.of(0, 1);
         Page<ChatMessage> pagedChatMessage = chatMessageRepository.findRecentMessagesByChatRoomId(chatRoomId,

--- a/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/application/room/ChatRoomQueryServiceImpl.java
@@ -90,7 +90,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
 
     @Override
     public Page<ChatRoom> getPagedChatRoomListByKeyword(String keyword, Pageable pageable) {
-        return chatRoomRepository.searchByKeyword(keyword, pageable);
+        return chatRoomRepository.findChatRoomsByKeyword(keyword, pageable);
     }
 
     private Optional<ChatMessage> findLastChatMessageByChatRoomId(Long chatRoomId) {

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepository.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepository.java
@@ -1,6 +1,7 @@
 package com.example.waggle.domain.chat.persistence.dao.querydsl;
 
 import com.example.waggle.domain.chat.persistence.entity.ChatRoom;
+import com.example.waggle.domain.member.persistence.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -11,5 +12,7 @@ public interface ChatRoomQueryRepository {
     Long countChatRoomsByMemberId(Long memberId);
 
     Page<ChatRoom> findChatRoomsByKeyword(String keyword, Pageable pageable);
+
+    Page<ChatRoom> findChatRoomsByKeywordExcludingMember(Member member, String keyword, Pageable pageable);
 
 }

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepository.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepository.java
@@ -10,6 +10,6 @@ public interface ChatRoomQueryRepository {
 
     Long countChatRoomsByMemberId(Long memberId);
 
-    Page<ChatRoom> searchByKeyword(String keyword, Pageable pageable);
+    Page<ChatRoom> findChatRoomsByKeyword(String keyword, Pageable pageable);
 
 }

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepositoryImpl.java
@@ -75,9 +75,9 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
             countQuery.where(chatRoom.name.contains(keyword).or(chatRoom.description.contains(keyword)));
         }
 
-        baseQuery.leftJoin(chatRoom.chatRoomMembers, chatRoomMember)
+        baseQuery.join(chatRoom.chatRoomMembers, chatRoomMember)
                 .where(chatRoomMember.member.id.ne(member.getId()).or(chatRoomMember.member.id.isNull()));
-        countQuery.leftJoin(chatRoom.chatRoomMembers, chatRoomMember)
+        countQuery.join(chatRoom.chatRoomMembers, chatRoomMember)
                 .where(chatRoomMember.member.id.ne(member.getId()).or(chatRoomMember.member.id.isNull()));
 
         List<ChatRoom> chatRooms = baseQuery

--- a/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/example/waggle/domain/chat/persistence/dao/querydsl/ChatRoomQueryRepositoryImpl.java
@@ -76,9 +76,9 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
         }
 
         baseQuery.join(chatRoom.chatRoomMembers, chatRoomMember)
-                .where(chatRoomMember.member.id.ne(member.getId()).or(chatRoomMember.member.id.isNull()));
+                .where(chatRoomMember.member.id.ne(member.getId()));
         countQuery.join(chatRoom.chatRoomMembers, chatRoomMember)
-                .where(chatRoomMember.member.id.ne(member.getId()).or(chatRoomMember.member.id.isNull()));
+                .where(chatRoomMember.member.id.ne(member.getId()));
 
         List<ChatRoom> chatRooms = baseQuery
                 .offset(pageable.getOffset())

--- a/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
+++ b/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
@@ -206,4 +206,20 @@ public class ChatApiController {
                 ChatConverter.toChatRoomListDto(chatRoomQueryService.getPagedChatRoomListByKeyword(keyword, pageable)));
     }
 
+    @Operation(summary = "채팅방 검색 🔑",
+            description = "주어진 키워드를 기반으로 회원이 속하지 않은 채팅방을 검색합니다.(name, description) 키워드는 최소 2자 이상이어야 합니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
+    @GetMapping("/rooms/search/auth")
+    public ApiResponseDto<ChatRoomListDto> searchChatRoomListExcludingUser(
+            @AuthUser Member member,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
+        ObjectUtil.validateKeywordLength(keyword);
+        Pageable pageable = PageRequest.of(currentPage, CHAT_ROOM_SIZE, PageUtil.LATEST_SORTING);
+        return ApiResponseDto.onSuccess(
+                ChatConverter.toChatRoomListDto(
+                        chatRoomQueryService.getPagedChatRoomListByKeywordExcludingMember(member, keyword, pageable)));
+    }
 }

--- a/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
+++ b/src/main/java/com/example/waggle/domain/chat/presentation/controller/ChatApiController.java
@@ -198,7 +198,7 @@ public class ChatApiController {
     })
     @GetMapping("/rooms/search")
     public ApiResponseDto<ChatRoomListDto> searchChatRoomList(
-            @RequestParam("keyword") String keyword,
+            @RequestParam(value = "keyword", required = false) String keyword,
             @RequestParam(name = "currentPage", defaultValue = "0") int currentPage) {
         ObjectUtil.validateKeywordLength(keyword);
         Pageable pageable = PageRequest.of(currentPage, CHAT_ROOM_SIZE, PageUtil.LATEST_SORTING);


### PR DESCRIPTION
## 🔎 Description
> Integrate Chat Room APIs and Exclude User's Chat Rooms
- 채팅방 전체 조회 API 및 검색 API 통합
- 사용자가 속한 채팅방 제외한 검색 API 구현


## 🔗 Related Issue
- [https://github.com/teamWaggle/Waggle-server/issues/302](https://github.com/teamWaggle/Waggle-server/issues/302)


## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
