### PR TITLE
[Refactor/#291] refactor overall team business logic

### DIFF
--- a/src/main/java/com/example/waggle/domain/schedule/application/ScheduleCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/ScheduleCommandServiceImpl.java
@@ -75,7 +75,6 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
         if (!boardService.validateMemberUseBoard(scheduleId, SCHEDULE, member)) {
             throw new ScheduleHandler(ErrorStatus.BOARD_CANNOT_EDIT_OTHERS);
         }
-        //TODO add validator : remove only memberSchedule count is zero(need to talk when meeting)
         commentRepository.deleteCommentsWithRelationsByBoard(scheduleId);
         boardRepository.deleteBoardsWithRelations(SCHEDULE, scheduleId);
     }
@@ -104,11 +103,6 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
 
     @Override
     public void deleteMemberSchedule(Long scheduleId, Member member) {
-        Schedule schedule = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new ScheduleHandler(ErrorStatus.SCHEDULE_NOT_FOUND));
-
-        validateScheduleIsInYourTeam(schedule, member);
-
         memberScheduleRepository.deleteByMemberIdAndScheduleId(member.getId(), scheduleId);
     }
 

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamCommandServiceImpl.java
@@ -46,7 +46,7 @@ public class TeamCommandServiceImpl implements TeamCommandService {
         Team team = buildTeam(createTeamRequest, member);
         teamRepository.save(team);
         addMemberToTeam(team, member);
-        buildParticipation(member, team, ParticipationStatus.ACCEPTED);
+        participationRepository.save(buildParticipation(member, team, ParticipationStatus.ACCEPTED));
         return team.getId();
     }
 

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamCommandServiceImpl.java
@@ -37,7 +37,7 @@ public class TeamCommandServiceImpl implements TeamCommandService {
     private final ParticipationRepository participationRepository;
     private final NotificationRepository notificationRepository;
     private final AwsS3Service awsS3Service;
-    private final int teamCapacityLimit = 15;
+    private final int teamCapacityLimit = 20;
 
     @Override
     public Long createTeam(TeamRequest createTeamRequest, Member member) {

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamCommandServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamCommandServiceImpl.java
@@ -46,6 +46,7 @@ public class TeamCommandServiceImpl implements TeamCommandService {
         Team team = buildTeam(createTeamRequest, member);
         teamRepository.save(team);
         addMemberToTeam(team, member);
+        buildParticipation(member, team, ParticipationStatus.ACCEPTED);
         return team.getId();
     }
 

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryService.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryService.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface TeamQueryService {
 
@@ -21,10 +20,6 @@ public interface TeamQueryService {
     Team getTeamById(Long teamId);
 
     List<Participation> getParticipationList(Member leader, Long teamId);
-
-    Optional<Participation> getParticipation(Member member, Long teamId);
-
-    boolean isMemberOfTeam(Member member, Long teamId);
 
     Status getParticipationStatus(Member member, Long teamId);
 }

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryService.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryService.java
@@ -3,6 +3,7 @@ package com.example.waggle.domain.schedule.application;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.schedule.persistence.entity.Participation;
 import com.example.waggle.domain.schedule.persistence.entity.Team;
+import com.example.waggle.domain.schedule.presentation.dto.team.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -25,4 +26,5 @@ public interface TeamQueryService {
 
     boolean isMemberOfTeam(Member member, Long teamId);
 
+    Status getParticipationStatus(Member member, Long teamId);
 }

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryService.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryService.java
@@ -3,7 +3,7 @@ package com.example.waggle.domain.schedule.application;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.schedule.persistence.entity.Participation;
 import com.example.waggle.domain.schedule.persistence.entity.Team;
-import com.example.waggle.domain.schedule.presentation.dto.team.Status;
+import com.example.waggle.domain.schedule.presentation.dto.team.ParticipationStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -21,5 +21,5 @@ public interface TeamQueryService {
 
     List<Participation> getParticipationList(Member leader, Long teamId);
 
-    Status getParticipationStatus(Member member, Long teamId);
+    ParticipationStatus getParticipationStatus(Member member, Long teamId);
 }

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryServiceImpl.java
@@ -2,9 +2,11 @@ package com.example.waggle.domain.schedule.application;
 
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.schedule.persistence.dao.jpa.ParticipationRepository;
+import com.example.waggle.domain.schedule.persistence.dao.jpa.TeamMemberRepository;
 import com.example.waggle.domain.schedule.persistence.dao.jpa.TeamRepository;
 import com.example.waggle.domain.schedule.persistence.entity.Participation;
 import com.example.waggle.domain.schedule.persistence.entity.Team;
+import com.example.waggle.domain.schedule.presentation.dto.team.Status;
 import com.example.waggle.exception.object.handler.TeamHandler;
 import com.example.waggle.exception.payload.code.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import java.util.Optional;
 public class TeamQueryServiceImpl implements TeamQueryService {
 
     private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
     private final ParticipationRepository participationRepository;
 
     @Override
@@ -71,5 +74,16 @@ public class TeamQueryServiceImpl implements TeamQueryService {
                 .orElseThrow(() -> new TeamHandler(ErrorStatus.TEAM_NOT_FOUND));
         return team.getTeamMembers().stream()
                 .anyMatch(teamMember -> teamMember.getMember().equals(member));
+    }
+
+    @Override
+    public Status getParticipationStatus(Member member, Long teamId) {
+        if (teamMemberRepository.existsByMemberIdAndTeamId(member.getId(), teamId)) {
+            return Status.ACCEPTED;
+        }
+        if (participationRepository.existsByMemberIdAndTeamId(member.getId(), teamId)) {
+            return Status.PENDING;
+        }
+        return Status.NONE;
     }
 }

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryServiceImpl.java
@@ -50,10 +50,14 @@ public class TeamQueryServiceImpl implements TeamQueryService {
     public List<Participation> getParticipationList(Member leader, Long teamId) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new TeamHandler(ErrorStatus.TEAM_NOT_FOUND));
+        validateIsLeader(leader, team);
+        return participationRepository.findByTeam(team);
+    }
+
+    private static void validateIsLeader(Member leader, Team team) {
         if (!team.getLeader().equals(leader)) {
             throw new TeamHandler(ErrorStatus.TEAM_LEADER_UNAUTHORIZED);
         }
-        return participationRepository.findByTeamAndStatus(team, ParticipationStatus.PENDING);
     }
 
     @Override

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryServiceImpl.java
@@ -4,7 +4,6 @@ import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.schedule.persistence.dao.jpa.ParticipationRepository;
 import com.example.waggle.domain.schedule.persistence.dao.jpa.TeamRepository;
 import com.example.waggle.domain.schedule.persistence.entity.Participation;
-import com.example.waggle.domain.schedule.persistence.entity.ParticipationStatus;
 import com.example.waggle.domain.schedule.persistence.entity.Team;
 import com.example.waggle.exception.object.handler.TeamHandler;
 import com.example.waggle.exception.payload.code.ErrorStatus;

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryServiceImpl.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -61,19 +60,6 @@ public class TeamQueryServiceImpl implements TeamQueryService {
         if (!team.getLeader().equals(leader)) {
             throw new TeamHandler(ErrorStatus.TEAM_LEADER_UNAUTHORIZED);
         }
-    }
-
-    @Override
-    public Optional<Participation> getParticipation(Member member, Long teamId) {
-        return participationRepository.findByTeamIdAndMemberId(teamId, member.getId());
-    }
-
-    @Override
-    public boolean isMemberOfTeam(Member member, Long teamId) {
-        Team team = teamRepository.findById(teamId)
-                .orElseThrow(() -> new TeamHandler(ErrorStatus.TEAM_NOT_FOUND));
-        return team.getTeamMembers().stream()
-                .anyMatch(teamMember -> teamMember.getMember().equals(member));
     }
 
     @Override

--- a/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryServiceImpl.java
+++ b/src/main/java/com/example/waggle/domain/schedule/application/TeamQueryServiceImpl.java
@@ -6,7 +6,7 @@ import com.example.waggle.domain.schedule.persistence.dao.jpa.TeamMemberReposito
 import com.example.waggle.domain.schedule.persistence.dao.jpa.TeamRepository;
 import com.example.waggle.domain.schedule.persistence.entity.Participation;
 import com.example.waggle.domain.schedule.persistence.entity.Team;
-import com.example.waggle.domain.schedule.presentation.dto.team.Status;
+import com.example.waggle.domain.schedule.presentation.dto.team.ParticipationStatus;
 import com.example.waggle.exception.object.handler.TeamHandler;
 import com.example.waggle.exception.payload.code.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -63,13 +63,13 @@ public class TeamQueryServiceImpl implements TeamQueryService {
     }
 
     @Override
-    public Status getParticipationStatus(Member member, Long teamId) {
+    public ParticipationStatus getParticipationStatus(Member member, Long teamId) {
         if (teamMemberRepository.existsByMemberIdAndTeamId(member.getId(), teamId)) {
-            return Status.ACCEPTED;
+            return ParticipationStatus.ACCEPTED;
         }
         if (participationRepository.existsByMemberIdAndTeamId(member.getId(), teamId)) {
-            return Status.PENDING;
+            return ParticipationStatus.PENDING;
         }
-        return Status.NONE;
+        return ParticipationStatus.NONE;
     }
 }

--- a/src/main/java/com/example/waggle/domain/schedule/persistence/dao/jpa/ParticipationRepository.java
+++ b/src/main/java/com/example/waggle/domain/schedule/persistence/dao/jpa/ParticipationRepository.java
@@ -22,6 +22,5 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     void deleteByMemberIdAndTeamId(Long memberId, Long teamId);
 
-    List<Participation> findByTeamAndStatus(Team team, ParticipationStatus status);
-
+    List<Participation> findByTeam(Team team);
 }

--- a/src/main/java/com/example/waggle/domain/schedule/persistence/dao/jpa/ParticipationRepository.java
+++ b/src/main/java/com/example/waggle/domain/schedule/persistence/dao/jpa/ParticipationRepository.java
@@ -23,4 +23,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     void deleteByMemberIdAndTeamId(Long memberId, Long teamId);
 
     List<Participation> findByTeam(Team team);
+
+    boolean existsByMemberIdAndTeamId(Long memberId, Long teamId);
 }

--- a/src/main/java/com/example/waggle/domain/schedule/persistence/dao/jpa/ParticipationRepository.java
+++ b/src/main/java/com/example/waggle/domain/schedule/persistence/dao/jpa/ParticipationRepository.java
@@ -21,6 +21,8 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     void deleteByMemberAndTeam(Member member, Team team);
 
+    void deleteByMemberIdAndTeamId(Long memberId, Long teamId);
+
     List<Participation> findByTeamAndStatus(Team team, ParticipationStatus status);
 
 }

--- a/src/main/java/com/example/waggle/domain/schedule/persistence/dao/jpa/ParticipationRepository.java
+++ b/src/main/java/com/example/waggle/domain/schedule/persistence/dao/jpa/ParticipationRepository.java
@@ -2,7 +2,6 @@ package com.example.waggle.domain.schedule.persistence.dao.jpa;
 
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.schedule.persistence.entity.Participation;
-import com.example.waggle.domain.schedule.persistence.entity.ParticipationStatus;
 import com.example.waggle.domain.schedule.persistence.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/example/waggle/domain/schedule/persistence/dao/jpa/TeamMemberRepository.java
+++ b/src/main/java/com/example/waggle/domain/schedule/persistence/dao/jpa/TeamMemberRepository.java
@@ -19,4 +19,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     void deleteAllByTeam(Team team);
 
     int countByTeam(Team team);
+
+    boolean existsByMemberIdAndTeamId(Long memberId, Long teamId);
 }

--- a/src/main/java/com/example/waggle/domain/schedule/persistence/entity/Participation.java
+++ b/src/main/java/com/example/waggle/domain/schedule/persistence/entity/Participation.java
@@ -2,22 +2,12 @@ package com.example.waggle.domain.schedule.persistence.entity;
 
 
 import com.example.waggle.domain.member.persistence.entity.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Builder
 @Getter
@@ -39,10 +29,5 @@ public class Participation {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
-
-    @Setter
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private ParticipationStatus status;
 
 }

--- a/src/main/java/com/example/waggle/domain/schedule/persistence/entity/ParticipationStatus.java
+++ b/src/main/java/com/example/waggle/domain/schedule/persistence/entity/ParticipationStatus.java
@@ -1,5 +1,5 @@
 package com.example.waggle.domain.schedule.persistence.entity;
 
 public enum ParticipationStatus {
-    PENDING, ACCEPTED, REJECTED
+    PENDING, ACCEPTED
 }

--- a/src/main/java/com/example/waggle/domain/schedule/persistence/entity/ParticipationStatus.java
+++ b/src/main/java/com/example/waggle/domain/schedule/persistence/entity/ParticipationStatus.java
@@ -1,5 +1,0 @@
-package com.example.waggle.domain.schedule.persistence.entity;
-
-public enum ParticipationStatus {
-    PENDING, ACCEPTED
-}

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/controller/TeamApiController.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/controller/TeamApiController.java
@@ -206,8 +206,7 @@ public class TeamApiController {
     public ApiResponseDto<ParticipationStatusResponse> getTeamParticipationStatus(@AuthUser Member member,
                                                                                   @PathVariable("teamId") Long teamId) {
         Optional<Participation> participation = teamQueryService.getParticipation(member, teamId);
-        boolean isMember = teamQueryService.isMemberOfTeam(member, teamId);
-        return ApiResponseDto.onSuccess(TeamConverter.toStatusDto(participation, isMember));
+        return ApiResponseDto.onSuccess(TeamConverter.toStatusDto(participation));
     }
 
     @Operation(summary = "사용자 팀 조회", description = "해당 사용자가 속한 팀 정보를 페이징하여 제공합니다.")

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/controller/TeamApiController.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/controller/TeamApiController.java
@@ -30,7 +30,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.example.waggle.global.annotation.api.PredefinedErrorStatus.ADMIN;
@@ -205,8 +204,7 @@ public class TeamApiController {
     @GetMapping("/{teamId}/participation/status")
     public ApiResponseDto<ParticipationStatusResponse> getTeamParticipationStatus(@AuthUser Member member,
                                                                                   @PathVariable("teamId") Long teamId) {
-        Optional<Participation> participation = teamQueryService.getParticipation(member, teamId);
-        return ApiResponseDto.onSuccess(TeamConverter.toStatusDto(participation));
+        return ApiResponseDto.onSuccess(TeamConverter.toStatusDto(teamQueryService.getParticipationStatus(member, teamId)));
     }
 
     @Operation(summary = "사용자 팀 조회", description = "해당 사용자가 속한 팀 정보를 페이징하여 제공합니다.")

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/converter/TeamConverter.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/converter/TeamConverter.java
@@ -3,7 +3,7 @@ package com.example.waggle.domain.schedule.presentation.converter;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.member.presentation.converter.MemberConverter;
 import com.example.waggle.domain.schedule.persistence.entity.Team;
-import com.example.waggle.domain.schedule.presentation.dto.team.Status;
+import com.example.waggle.domain.schedule.presentation.dto.team.ParticipationStatus;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.ParticipationStatusResponse;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.TeamDetailDto;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.TeamSummaryDto;
@@ -58,9 +58,9 @@ public class TeamConverter {
                 .build();
     }
 
-    public static ParticipationStatusResponse toStatusDto(Status status) {
+    public static ParticipationStatusResponse toStatusDto(ParticipationStatus participationStatus) {
         return ParticipationStatusResponse.builder()
-                .status(status)
+                .participationStatus(participationStatus)
                 .build();
     }
 

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/converter/TeamConverter.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/converter/TeamConverter.java
@@ -2,10 +2,9 @@ package com.example.waggle.domain.schedule.presentation.converter;
 
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.member.presentation.converter.MemberConverter;
-import com.example.waggle.domain.schedule.persistence.entity.Participation;
 import com.example.waggle.domain.schedule.persistence.entity.Team;
+import com.example.waggle.domain.schedule.presentation.dto.team.Status;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.ParticipationStatusResponse;
-import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.ParticipationStatusResponse.Status;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.TeamDetailDto;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.TeamSummaryDto;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.TeamSummaryListDto;
@@ -13,7 +12,6 @@ import com.example.waggle.global.util.MediaUtil;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class TeamConverter {
@@ -60,19 +58,10 @@ public class TeamConverter {
                 .build();
     }
 
-    public static ParticipationStatusResponse toStatusDto(Optional<Participation> participation) {
-        Status status = Status.NONE;
-        if (participation.isPresent()) {
-            switch (participation.get().getStatus()) {
-                case PENDING -> status = Status.PENDING;
-                case ACCEPTED -> status = Status.ACCEPTED;
-                default -> status = Status.NONE;
-            }
-        }
+    public static ParticipationStatusResponse toStatusDto(Status status) {
         return ParticipationStatusResponse.builder()
                 .status(status)
                 .build();
-
     }
 
 }

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/converter/TeamConverter.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/converter/TeamConverter.java
@@ -3,14 +3,13 @@ package com.example.waggle.domain.schedule.presentation.converter;
 import com.example.waggle.domain.member.persistence.entity.Member;
 import com.example.waggle.domain.member.presentation.converter.MemberConverter;
 import com.example.waggle.domain.schedule.persistence.entity.Participation;
-import com.example.waggle.domain.schedule.persistence.entity.ParticipationStatus;
 import com.example.waggle.domain.schedule.persistence.entity.Team;
-import com.example.waggle.global.util.MediaUtil;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.ParticipationStatusResponse;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.ParticipationStatusResponse.Status;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.TeamDetailDto;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.TeamSummaryDto;
 import com.example.waggle.domain.schedule.presentation.dto.team.TeamResponse.TeamSummaryListDto;
+import com.example.waggle.global.util.MediaUtil;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -61,15 +60,17 @@ public class TeamConverter {
                 .build();
     }
 
-    public static ParticipationStatusResponse toStatusDto(Optional<Participation> participation, boolean isMember) {
-        ParticipationStatus status = ParticipationStatus.REJECTED;
+    public static ParticipationStatusResponse toStatusDto(Optional<Participation> participation) {
+        Status status = Status.NONE;
         if (participation.isPresent()) {
-            status = participation.get().getStatus();
-        } else if (isMember) {
-            status = ParticipationStatus.ACCEPTED;
+            switch (participation.get().getStatus()) {
+                case PENDING -> status = Status.PENDING;
+                case ACCEPTED -> status = Status.ACCEPTED;
+                default -> status = Status.NONE;
+            }
         }
         return ParticipationStatusResponse.builder()
-                .status(Status.valueOf(String.valueOf(status)))
+                .status(status)
                 .build();
 
     }

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/dto/team/ParticipationStatus.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/dto/team/ParticipationStatus.java
@@ -1,5 +1,5 @@
 package com.example.waggle.domain.schedule.presentation.dto.team;
 
-public enum Status {
+public enum ParticipationStatus {
     PENDING, ACCEPTED, NONE
 }

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/dto/team/Status.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/dto/team/Status.java
@@ -1,0 +1,5 @@
+package com.example.waggle.domain.schedule.presentation.dto.team;
+
+public enum Status {
+    PENDING, ACCEPTED, NONE
+}

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/dto/team/TeamResponse.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/dto/team/TeamResponse.java
@@ -63,7 +63,7 @@ public class TeamResponse {
     @Schema
     public static class ParticipationStatusResponse {
 
-        private Status status;
+        private ParticipationStatus participationStatus;
     }
 
 }

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/dto/team/TeamResponse.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/dto/team/TeamResponse.java
@@ -64,14 +64,6 @@ public class TeamResponse {
     public static class ParticipationStatusResponse {
 
         private Status status;
-
-        public enum Status {
-            PENDING, ACCEPTED, NONE
-        }
-
-        public void setStatus(Status status) {
-            this.status = status;
-        }
     }
 
 }

--- a/src/main/java/com/example/waggle/domain/schedule/presentation/dto/team/TeamResponse.java
+++ b/src/main/java/com/example/waggle/domain/schedule/presentation/dto/team/TeamResponse.java
@@ -1,7 +1,7 @@
 package com.example.waggle.domain.schedule.presentation.dto.team;
 
-import com.example.waggle.domain.schedule.persistence.entity.TeamColor;
 import com.example.waggle.domain.member.presentation.dto.MemberResponse.MemberSummaryDto;
+import com.example.waggle.domain.schedule.persistence.entity.TeamColor;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -66,7 +66,7 @@ public class TeamResponse {
         private Status status;
 
         public enum Status {
-            PENDING, ACCEPTED, REJECTED, NONE
+            PENDING, ACCEPTED, NONE
         }
 
         public void setStatus(Status status) {


### PR DESCRIPTION
## 🔎 Description
> refactor team business logic
1. team leader 권한(모든 권한 부여)
2. team leader 권한 제한(팀 나가기 불가능)
3. team 수용 인원 20으로 제한
4. schedule 작성자 권한(작성, 수정, 삭제, 취소)
5. participation -> pending status의 역할로 변경
6. team_member -> accepted status의 역할로 변경


## 🔗 Related Issue
- https://github.com/teamWaggle/Waggle-server/issues/291


## 🏷️ What type of PR is this?
- [ ] ✨ Feature
- [x] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
